### PR TITLE
[CI] - ensure SDK 27 is installed for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-25-alpha
+      - image: circleci/android:api-27-alpha
     environment:
       JVM_OPTS: -Xmx3200m
     steps:


### PR DESCRIPTION
The existing config file erroneously requests an image with SDK 25 instead. Perhaps this will fix the failures we've been seeing?