### PR TITLE
Map department pins are transient (AIC-251)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
@@ -24,8 +24,16 @@ interface ArticObjectDao {
     @Query("select * from ArticObject where objectSelectorNumber = :selectorNumber")
     fun getObjectBySelectorNumber(selectorNumber: String): Single<ArticObject>
 
-    @Query("select * from ArticObject where galleryLocation in (:galleryTitleList)")
-    fun getObjectsInGalleries(galleryTitleList: List<String>) : Flowable<List<ArticObject>>
+    /**
+     * Retrieves all of the [ArticObject]s found in a specific
+     * gallery. May be an empty list if none claim to belong to
+     * the given gallery.
+     *
+     * @see ArticObject.galleryLocation
+     * @see edu.artic.db.models.ArticGallery.floor
+     */
+    @Query("select * from ArticObject where galleryLocation in (:galleryTitle)")
+    fun getObjectsInGallery(galleryTitle: String) : List<ArticObject>
 
 
 }

--- a/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
@@ -16,6 +16,12 @@ data class ArticGallery(
         @Json(name = "latitude" ) val latitude: Double,
         @Json(name = "longitude" ) val longitude: Double,
         @Json(name = "floor" ) val floor: String?,
+        /**
+         * NB: as established by the iOS codebase, please use [title] instead of this field.
+         *
+         * In the general sense we expect the two fields to be equivalent and this one may
+         * be removed from the dta model in a future commit.
+         */
         @Json(name = "title_t" ) val titleT: String?,
         @Json(name = "gallery_id" ) val galleryId: String?,
         @Json(name = "is_boosted" ) val isBoosted: Boolean,

--- a/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
@@ -23,4 +23,10 @@ data class ArticGallery(
         @Json(name = "closed" ) val closed: Boolean,
         @Json(name = "number" ) val number: String?,
         @Json(name = "category_titles" ) val categoryTitles: List<String>
-)
+) {
+    /**
+     * Returns [floor], parsed to an integer. We default to [Int.MIN_VALUE] as 0 is a valid floor.
+     */
+    val floorAsInt: Int
+        get() = floor?.toIntOrNull() ?: Int.MIN_VALUE
+}

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -444,7 +444,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 }.disposedBy(disposeBag)
 
 
-        viewModel.veryDynamicMapItems
+        viewModel.whatToDisplayOnMap
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { itemList ->
                     departmentMarkers.forEach { marker ->

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -190,6 +190,21 @@ class MapViewModel @Inject constructor(
     }
 
     /**
+     * Observe for the Galleries which we're interested in at the moment.
+     *
+     * The returned [Observable] only emits events if the [current zoom level][zoomLevel]
+     * is set to [MapZoomLevel.Three], as that is a pre-requisite for galleries to be
+     * displayed on the map.
+     */
+    fun observeGalleriesAtFloor(): Observable<List<ArticGallery>> {
+        return observeFloorsAtZoom(MapZoomLevel.Three)
+                .flatMap {
+                    galleryDao.getGalleriesForFloor(it.toString()).toObservable()
+                }.share()
+        // Note: if we don't share this, only one observer could listen to it (we want 2 to do that)
+    }
+
+    /**
      * Observe the [ArticObject]s in the given list of galleries.
      *
      * One gallery may contain multiple objects; the returned observable
@@ -211,21 +226,6 @@ class MapViewModel @Inject constructor(
                 }
             }.flatten()
         }
-    }
-
-    /**
-     * Observe for the Galleries which we're interested in at the moment.
-     *
-     * The returned [Observable] only emits events if the [current zoom level][zoomLevel]
-     * is set to [MapZoomLevel.Three], as that is a pre-requisite for galleries to be
-     * displayed on the map.
-     */
-    fun observeGalleriesAtFloor(): Observable<List<ArticGallery>> {
-        return observeFloorsAtZoom(MapZoomLevel.Three)
-                .flatMap {
-                    galleryDao.getGalleriesForFloor(it.toString()).toObservable()
-                }.share()
-        // Note: if we don't share this, only one observer could listen to it (we want 2 to do that)
     }
 
     fun zoomLevelChangedTo(zoomLevel: MapZoomLevel) {

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -184,7 +184,8 @@ class MapViewModel @Inject constructor(
                         objectList
                 )
             }
-        }.filter { it.isNotEmpty() }
+        }
+                // We explicitly permit emission of empty lists, as that is a signal to clear the map.
                 .bindTo(whatToDisplayOnMap)
                 .disposedBy(disposeBag)
     }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -175,12 +175,12 @@ class MapViewModel @Inject constructor(
                 zoomLevel,
                 galleries,
                 objects
-        ) { floor, zoomLevel, galleryList, objectList ->
-            return@combineLatest if (zoomLevel == MapZoomLevel.Three && floor == currentFloor) {
+        ) { ourFloor, ourZoom, galleryList, objectList ->
+            return@combineLatest if (ourZoom == MapZoomLevel.Three && ourFloor == currentFloor) {
                 val list = mutableListOf<MapItem<*>>()
                 list.addAll(
                         galleryList.map { gallery ->
-                            MapItem.Gallery(gallery, floor)
+                            MapItem.Gallery(gallery, gallery.floorAsInt)
                         }
                 )
                 list.addAll(

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -20,6 +20,17 @@ import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import javax.inject.Inject
 
+/**
+ * Backing logic for the markers we display in [MapFragment].
+ *
+ * What we display there is informed directly by the [zoomLevel] and
+ * the [floor]. Observables defined in this class will (as a rule)
+ * only emit an event if those properties change.
+ *
+ * Everything starts with `init`.
+ *
+ * @see MapItem
+ */
 class MapViewModel @Inject constructor(
         private val mapAnnotationDao: ArticMapAnnotationDao,
         private val galleryDao: ArticGalleryDao,
@@ -30,7 +41,9 @@ class MapViewModel @Inject constructor(
     val spacesAndLandmarks: Subject<List<MapItem.Annotation>> = BehaviorSubject.create()
     val selectedArticObject: Subject<ArticObject> = BehaviorSubject.create()
 
-    //This stores all the map items that change at every zoom level and every floor change
+    /**
+     * This stores all the map items that change at every zoom level and every floor change
+     */
     val veryDynamicMapItems: Subject<List<MapItem<*>>> = BehaviorSubject.create()
 
 
@@ -170,6 +183,14 @@ class MapViewModel @Inject constructor(
                 .disposedBy(disposeBag)
     }
 
+    /**
+     * Observe the [ArticObject]s in the given list of galleries.
+     *
+     * One gallery may contain multiple objects; the returned observable
+     * returns all of the objects it finds as a single list. The mechanism
+     * we use to retrieve these objects precludes the possibility of
+     * duplicates.
+     */
     fun observeObjectsWithin(galleries: Observable<List<ArticGallery>>): Observable<List<ArticObject>> {
         return galleries
                 .map { galleryList ->
@@ -179,6 +200,13 @@ class MapViewModel @Inject constructor(
                 }
     }
 
+    /**
+     * Observe for the Galleries which we're interested in at the moment.
+     *
+     * The returned [Observable] only emits events if the [current zoom level][zoomLevel]
+     * is set to [MapZoomLevel.Three], as that is a pre-requisite for galleries to be
+     * displayed on the map.
+     */
     fun observeGalleriesAtFloor(): Observable<List<ArticGallery>> {
         return Observables.combineLatest(
                 zoomLevel,

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -171,24 +171,18 @@ class MapViewModel @Inject constructor(
         val objects = observeObjectsWithin(galleries)
 
         Observables.combineLatest(
-                distinctFloor,
-                zoomLevel,
                 galleries,
                 objects
-        ) { ourFloor, ourZoom, galleryList, objectList ->
-            return@combineLatest if (ourZoom == MapZoomLevel.Three && ourFloor == currentFloor) {
-                val list = mutableListOf<MapItem<*>>()
-                list.addAll(
-                        galleryList.map { gallery ->
-                            MapItem.Gallery(gallery, gallery.floorAsInt)
-                        }
+        ) { galleryList, objectList ->
+            mutableListOf<MapItem<*>>().apply {
+                addAll(
+                    galleryList.map { gallery ->
+                        MapItem.Gallery(gallery, gallery.floorAsInt)
+                    }
                 )
-                list.addAll(
+                addAll(
                         objectList
                 )
-                list
-            } else {
-                emptyList<MapItem<*>>()
             }
         }.filter { it.isNotEmpty() }
                 .bindTo(whatToDisplayOnMap)

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -219,9 +219,9 @@ class MapViewModel @Inject constructor(
     fun observeObjectsWithin(observed: Observable<List<ArticGallery>>): Observable<List<MapItem.Object>> {
         return observed.map { galleries ->
             galleries.filter { gallery ->
-                gallery.titleT != null
+                gallery.title != null
             }.map { gallery ->
-                val title = gallery.titleT.orEmpty()
+                val title = gallery.title.orEmpty()
                 objectDao.getObjectsInGallery(title).map {
                     MapItem.Object(it, gallery.floorAsInt)
                 }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -42,9 +42,13 @@ class MapViewModel @Inject constructor(
     val selectedArticObject: Subject<ArticObject> = BehaviorSubject.create()
 
     /**
-     * This stores all the map items that change at every zoom level and every floor change
+     * This stores all the map items, and changes at every zoom level and every floor.
+     *
+     * We strongly recommend familiarity with the [MapItem] type before using this field. This
+     * Observable is expected to emit events rather frequently, so for the best performance
+     * you'll probably want to minimize allocations in whatever you have observing it.
      */
-    val veryDynamicMapItems: Subject<List<MapItem<*>>> = BehaviorSubject.create()
+    val whatToDisplayOnMap: Subject<List<MapItem<*>>> = BehaviorSubject.create()
 
 
     private val floor: Subject<Int> = BehaviorSubject.createDefault(1)
@@ -130,7 +134,7 @@ class MapViewModel @Inject constructor(
                 .map {
                     listOf<MapItem<*>>()
                 }
-                .bindTo(veryDynamicMapItems)
+                .bindTo(whatToDisplayOnMap)
                 .disposedBy(disposeBag)
     }
 
@@ -145,7 +149,7 @@ class MapViewModel @Inject constructor(
                 .flatMap { floor ->
                     mapAnnotationDao.getDepartmentOnMapForFloor(floor.toString()).toObservable()
                 }.map { it.mapToMapItem() }
-                .bindTo(veryDynamicMapItems)
+                .bindTo(whatToDisplayOnMap)
                 .disposedBy(disposeBag)
 
     }
@@ -179,7 +183,7 @@ class MapViewModel @Inject constructor(
                 emptyList<MapItem<*>>()
             }
         }.filter { it.isNotEmpty() }
-                .bindTo(veryDynamicMapItems)
+                .bindTo(whatToDisplayOnMap)
                 .disposedBy(disposeBag)
     }
 


### PR DESCRIPTION
This includes some much-wanted documentation of the `MapViewModel` class, as well as a fix for the inconsistent loading issue. As a bonus, we can now use the usual channels to tell the fragment that our map needs to be cleared of all markers.