### PR TITLE
[Glide] reduce error verbosity

### DIFF
--- a/base/src/main/java/edu/artic/base/utils/GlideRequestBuilderExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/GlideRequestBuilderExtensions.kt
@@ -1,6 +1,7 @@
 package edu.artic.base.utils
 
 import android.animation.ValueAnimator
+import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.support.v4.app.Fragment
 import android.view.View
@@ -10,6 +11,24 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+
+/**
+ * Simple mechanism for loading a full image and a thumbnail image from separate urls.
+ *
+ * The thumbnail request will only take the options currently set on 'this'; future
+ * calls to e.g. [this.setListener()][RequestBuilder.listener] will not affect it.
+ *
+ * Note that this method accepts null parameters since the underlying library
+ * accepts them. There are few (if any) tangible benefits to passing in null.
+ *
+ * @see [RequestBuilder.load]
+ * @see [RequestBuilder.thumbnail]
+ */
+fun RequestBuilder<Bitmap>.loadWithThumbnail(thumbUrl: String?, fullUrl: String?): RequestBuilder<Bitmap> {
+    return this.thumbnail(
+            clone().load(thumbUrl)
+    ).load(fullUrl)
+}
 
 /**
  * Adds listener that only cares about returning the drawable on success, and notifying that there

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -18,6 +18,7 @@ import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.fileAsString
 import edu.artic.base.utils.isResourceConstrained
 import edu.artic.base.utils.loadBitmap
+import edu.artic.base.utils.loadWithThumbnail
 import edu.artic.base.utils.statusBarHeight
 import edu.artic.db.models.*
 import edu.artic.map.carousel.TourCarouselFragment
@@ -627,7 +628,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private fun loadObject(articObject: ArticObject, floor: Int, displayMode: MapViewModel.DisplayMode) {
         Glide.with(this)
                 .asBitmap()
-                .load(articObject.thumbnailFullPath)
+                .loadWithThumbnail(articObject.thumbnailFullPath, articObject.fullImageFullPath)
                 .into(object : SimpleTarget<Bitmap>() {
                     override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
                         /**

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.support.annotation.AnyThread
 import android.view.View
 import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
 import com.fuzz.rx.*
@@ -628,6 +629,8 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private fun loadObject(articObject: ArticObject, floor: Int, displayMode: MapViewModel.DisplayMode) {
         Glide.with(this)
                 .asBitmap()
+                // The 'objectMarkerGenerator' used by the below target only supports bitmaps rendered in software
+                .apply(RequestOptions().disallowHardwareConfig())
                 .loadWithThumbnail(articObject.thumbnailFullPath, articObject.fullImageFullPath)
                 .into(object : SimpleTarget<Bitmap>() {
                     override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {

--- a/map/src/main/kotlin/edu/artic/map/util/ArticObjectMarkerGenerator.kt
+++ b/map/src/main/kotlin/edu/artic/map/util/ArticObjectMarkerGenerator.kt
@@ -5,32 +5,42 @@ import android.graphics.Bitmap
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
-import de.hdodenhof.circleimageview.CircleImageView
 import edu.artic.map.R
 
 
 class ArticObjectMarkerGenerator(context: Context) : BaseMarkerGenerator(context) {
 
-    private var imageView: CircleImageView
+    /**
+     * Where the [icon][BaseMarkerGenerator.makeIcon] will appear.
+     */
+    private val imageView: ImageView
+    private val overlayTextView: TextView
 
     init {
         container = LayoutInflater.from(context)
                 .inflate(R.layout.marker_artic_object, null) as ViewGroup
-         imageView = container.findViewById(R.id.circularImage)
+        imageView = container.findViewById(R.id.circularImage)
+        overlayTextView = container.findViewById(R.id.order)
     }
 
 
-    fun makeIcon(imageViewBitmap: Bitmap, order: String? = null): Bitmap {
+    /**
+     * NB: 'imageViewBitmap' _MUST_ be rendered in software. If its config
+     * is [android.graphics.Bitmap.Config.HARDWARE], the
+     * [CircleImageView][de.hdodenhof.circleimageview.CircleImageView]
+     * may crash.
+     */
+    fun makeIcon(imageViewBitmap: Bitmap, overlay: String? = null): Bitmap {
 
         imageView.setImageBitmap(imageViewBitmap)
 
-        val orderTextView = container.findViewById<TextView>(R.id.order)
-        if (order != null) {
-            orderTextView.visibility = View.VISIBLE
-            orderTextView.text = order
+        if (overlay != null) {
+            overlayTextView.visibility = View.VISIBLE
+            overlayTextView.text = overlay
         } else {
-            orderTextView.visibility = View.GONE
+            overlayTextView.visibility = View.GONE
         }
         return makeIcon()
     }

--- a/map/src/main/res/layout/marker_gallery_number.xml
+++ b/map/src/main/res/layout/marker_gallery_number.xml
@@ -1,12 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    tools:background="#fab"
+    >
 
     <TextView
-        style="@style/MarkerGalleryText"
         android:id="@+id/text"
+        style="@style/MarkerGalleryText"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        tools:text="1"
+        />
 
 </FrameLayout>

--- a/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
@@ -9,9 +9,20 @@ import com.bumptech.glide.request.RequestOptions
 
 
 /**
+ * This is the app's implementation of [our image-loading library's contract][AppGlideModule].
+ *
+ * Whenever code needs to load an image from a remote server, it should do so by
+ * calling [one of the Glide.with() overloads][com.bumptech.glide.Glide.with]. This
+ * file defines default values for those loading operations via [applyOptions].
+ *
+ * Note: the [GlideModule] annotation on this class is used by Glide's annotation
+ * processor during the build. There is no need for other source files to reference
+ * this file.
+ *
  * @author Sameer Dhakal (Fuzz)
  */
 @GlideModule
+@Suppress("unused")
 class GlideModule : AppGlideModule() {
 
     override fun applyOptions(context: Context?, builder: GlideBuilder?) {

--- a/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
@@ -25,9 +25,10 @@ import com.bumptech.glide.request.RequestOptions
 @Suppress("unused")
 class GlideModule : AppGlideModule() {
 
-    override fun applyOptions(context: Context?, builder: GlideBuilder?) {
-        super.applyOptions(context, builder)
-        builder?.setDefaultRequestOptions(RequestOptions().format(DecodeFormat.PREFER_ARGB_8888))
+    // NB: 'appcontext' and 'builder' are guaranteed non-null, based on analysis of sources for Glide 4.4.0
+    override fun applyOptions(appContext: Context, builder: GlideBuilder) {
+        super.applyOptions(appContext, builder)
+        builder.setDefaultRequestOptions(RequestOptions().format(DecodeFormat.PREFER_ARGB_8888))
 
     }
 

--- a/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.load.DecodeFormat
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.module.AppGlideModule
 import com.bumptech.glide.request.RequestOptions
+import com.bumptech.glide.request.target.SimpleTarget
 
 
 /**
@@ -27,12 +29,44 @@ class GlideModule : AppGlideModule() {
 
     // NB: 'appcontext' and 'builder' are guaranteed non-null, based on analysis of sources for Glide 4.4.0
     override fun applyOptions(appContext: Context, builder: GlideBuilder) {
-        super.applyOptions(appContext, builder)
-        builder.setDefaultRequestOptions(RequestOptions().format(DecodeFormat.PREFER_ARGB_8888))
+        builder.setDefaultRequestOptions(
+                RequestOptions()
+                        .format(DecodeFormat.PREFER_ARGB_8888)
+                        .downsample(MemoryOptimizedDownsampleStrategy)
+        )
 
     }
 
     override fun isManifestParsingEnabled(): Boolean {
         return false
+    }
+}
+
+
+/**
+ * A simple memory-aware strategy based on 'center outside'.
+ *
+ * Note this strategy only comes into effect if the source image and target
+ * ImageView are different sizes. To change the resolution of properly-sized
+ * resources, you'll need to use a new [DownsampleStrategy] and implement
+ * [DownsampleStrategy.getScaleFactor] accordingly.
+ *
+ * [MemoryOptimizedDownsampleStrategy.getScaleFactor] simply calls the method
+ * of the same name on [CENTER_OUTSIDE][DownsampleStrategy.CENTER_OUTSIDE]. The
+ * intended effect is for each image to be cropped in the larger dimension, so
+ * that every part of the [load target][SimpleTarget] is covered by some part of
+ * the image.
+ *
+ * As of Glide 4.4, the [default strategy][DownsampleStrategy.DEFAULT] was set to
+ * `CENTER_OUTSIDE` anyway, so our only distinction in that version is the use of
+ * [DownsampleStrategy.SampleSizeRounding.MEMORY].
+ */
+object MemoryOptimizedDownsampleStrategy : DownsampleStrategy() {
+    override fun getScaleFactor(sourceWidth: Int, sourceHeight: Int, requestedWidth: Int, requestedHeight: Int): Float {
+        return DownsampleStrategy.CENTER_OUTSIDE.getScaleFactor(sourceWidth, sourceHeight, requestedWidth, requestedHeight)
+    }
+
+    override fun getSampleSizeRounding(sourceWidth: Int, sourceHeight: Int, requestedWidth: Int, requestedHeight: Int): SampleSizeRounding {
+        return SampleSizeRounding.MEMORY
     }
 }

--- a/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/GlideModule.kt
@@ -1,6 +1,7 @@
 package edu.artic.welcome
 
 import android.content.Context
+import android.util.Log
 import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.load.DecodeFormat
@@ -29,6 +30,12 @@ class GlideModule : AppGlideModule() {
 
     // NB: 'appcontext' and 'builder' are guaranteed non-null, based on analysis of sources for Glide 4.4.0
     override fun applyOptions(appContext: Context, builder: GlideBuilder) {
+        if (BuildConfig.DEBUG) {
+            // 'INFO' includes 'ASSERT', 'ERROR', 'WARN' (call failed), and 'INFO' (call stacktrace) messages
+            builder.setLogLevel(Log.INFO)
+        } else {
+            builder.setLogLevel(Log.ERROR)
+        }
         builder.setDefaultRequestOptions(
                 RequestOptions()
                         .format(DecodeFormat.PREFER_ARGB_8888)


### PR DESCRIPTION
In release builds, glide will no longer print lots of stacktraces to logcat. Also:

* reduced memory usage when rendering a non-square image
* progressive loading of thumbnail then full image
