### PR TITLE
Convert LanguageAdapter implementation into RecyclerViewAdapter converter

### DIFF
--- a/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
@@ -86,24 +86,26 @@ class BaseAdapterBinder<TModel>(
         return viewType
     }
 
-    override fun getView(i: Int, view: View?, viewGroup: ViewGroup): View? {
-        var localView = view
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View? {
+        var localView = convertView
         val viewHolder: BaseViewHolder?
-        val viewType = adapter.getItemViewType(i)
+        val viewType = adapter.getItemViewType(position)
         if (localView == null || localView.getTag(R.id.tag_item_type) != viewType) {
-            viewHolder = adapter.createViewHolder(viewGroup, viewType)?.also {
+            viewHolder = adapter.createViewHolder(parent, viewType)?.also {
                 localView = applyViewHolderTags(it, viewType)
             }
         } else {
             viewHolder = localView?.getTag(R.id.tag_holder) as BaseViewHolder?
         }
 
-        viewHolder?.let { adapter.bindViewHolder(viewHolder, i) }
+        viewHolder?.let { adapter.bindViewHolder(viewHolder, position) }
         return localView
     }
 
     /**
-     * Defaults to the [getView] implementation if no helper is used.
+     * This is used when the dropdown view is open. The adapter must implement [DropDownAdapter] to
+     * gain hooks into the dropdown view functionality if you wanted to display a different view than
+     * what is returned in [getView], for example.
      */
     override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View? {
         if (adapter is DropDownAdapter<*, *> &&

--- a/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
@@ -1,0 +1,82 @@
+package edu.artic.adapter
+
+import android.support.v7.widget.RecyclerView
+import android.util.SparseIntArray
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Adapter
+import android.widget.BaseAdapter
+
+/**
+ * Description:
+ */
+fun <TModel> BaseRecyclerViewAdapter<TModel, *>.toBaseAdapter() = BaseAdapterBinder(this)
+
+/**
+ * Description: Provides a very simple compatibility layer between [BaseRecyclerViewAdapter]
+ * and [android.widget.BaseAdapter]. It enables reusing the [BaseRecyclerViewAdapter]
+ * without needing to use a different implementation.
+ * @author Andrew Grosner (Fuzz)
+ */
+open class BaseAdapterBinder<TModel>(
+        val adapter: BaseRecyclerViewAdapter<TModel, *>) : BaseAdapter() {
+
+    private var currentMaxViewType = 0
+    private val cachedLayoutIdToViewTypes = SparseIntArray()
+
+    init {
+        adapter.registerAdapterDataObserver(RecyclerViewToBaseAdapterObserver())
+    }
+
+    override fun getCount() = adapter.itemCount
+
+    override fun getItem(i: Int) = adapter.getItemOrNull(i)
+
+    override fun getItemId(i: Int) = i.toLong()
+
+    override fun getViewTypeCount() = 1 // override for proper view type counting
+
+    override fun getItemViewType(position: Int): Int {
+        val itemViewType = adapter.getItemViewType(position)
+        var viewType = cachedLayoutIdToViewTypes.get(itemViewType, Adapter.IGNORE_ITEM_VIEW_TYPE)
+        // cache and increment in order to keep ids in order as required by BaseAdapter
+        if (viewType == Adapter.IGNORE_ITEM_VIEW_TYPE) {
+            cachedLayoutIdToViewTypes.put(itemViewType, currentMaxViewType)
+            viewType = currentMaxViewType
+            currentMaxViewType++
+        }
+        return viewType
+    }
+
+    override fun getView(i: Int, view: View?, viewGroup: ViewGroup): View? {
+        var localView = view
+        val viewHolder: BaseViewHolder?
+        val viewType = adapter.getItemViewType(i)
+        if (localView == null || localView.getTag(R.id.tag_item_type) != viewType) {
+            viewHolder = adapter.createViewHolder(viewGroup, viewType)
+
+            if (viewHolder != null) {
+                localView = viewHolder.itemView
+                localView.setTag(R.id.tag_holder, viewHolder)
+                localView.setTag(R.id.tag_item_type, viewType)
+            }
+        } else {
+            viewHolder = localView.getTag(R.id.tag_holder) as BaseViewHolder?
+        }
+
+        viewHolder?.let { adapter.bindViewHolder(viewHolder, i) }
+        return localView
+    }
+
+    private inner class RecyclerViewToBaseAdapterObserver : RecyclerView.AdapterDataObserver() {
+        override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) = notifyDataSetChanged()
+
+        override fun onChanged() = notifyDataSetChanged()
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int) = notifyDataSetChanged()
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) = notifyDataSetChanged()
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) = notifyDataSetChanged()
+    }
+}

--- a/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
@@ -6,11 +6,48 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Adapter
 import android.widget.BaseAdapter
+import android.widget.Spinner
+import android.widget.SpinnerAdapter
 
 /**
  * Description:
  */
 fun <TModel> BaseRecyclerViewAdapter<TModel, *>.toBaseAdapter() = BaseAdapterBinder(this)
+
+/**
+ * Retrieve original [BaseRecyclerViewAdapter] from this [BaseAdapter]. It must be created with [toBaseAdapter] first.
+ * Must be a function due to Kotlin's type inference.
+ */
+@Suppress("UNCHECKED_CAST")
+fun <TModel> SpinnerAdapter.baseRecyclerViewAdapter(): BaseRecyclerViewAdapter<TModel, BaseViewHolder> =
+        (this as BaseAdapterBinder<TModel>).adapter as BaseRecyclerViewAdapter<TModel, BaseViewHolder>
+
+/**
+ * Implement this interface to add the ability for dropdown view functionality within a [Spinner], for example.
+ */
+interface DropDownAdapter<TModel, VH : BaseViewHolder> {
+
+    /**
+     * Return the item view based on type. The headers + footers will not be called from here. Those
+     * cannot be configured to display differently in this adapter.
+     */
+    fun onCreateDropdownItemViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder? =
+            BaseViewHolder(parent, viewType).apply {
+                itemView.onDropdownHolderCreated(parent, viewType)
+            }
+
+    fun onBindDropdownItemViewHolder(baseViewHolder: VH, item: TModel, position: Int) =
+            baseViewHolder.itemView.onBindDropdownView(item, position)
+
+    fun View.onBindDropdownView(item: TModel, position: Int) = Unit
+
+    /**
+     * Called when the [BaseViewHolder] is first created in the scope of it's itemView. Perform
+     * initial registering of view bindings here that respond outside normal onClickListener.
+     */
+    @Suppress("UNUSED_PARAMETER", "unused")
+    fun View.onDropdownHolderCreated(parent: ViewGroup, viewType: Int) = Unit
+}
 
 /**
  * Description: Provides a very simple compatibility layer between [BaseRecyclerViewAdapter]
@@ -66,6 +103,35 @@ open class BaseAdapterBinder<TModel>(
 
         viewHolder?.let { adapter.bindViewHolder(viewHolder, i) }
         return localView
+    }
+
+    /**
+     * Defaults to the [getView] implementation if no helper is used.
+     */
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View? {
+        if (adapter is DropDownAdapter<*, *> && !adapter.isFooterPosition(position) && !adapter.isHeaderPosition(position)) {
+            @Suppress("UNCHECKED_CAST")
+            val dropDownAdapter = adapter as DropDownAdapter<TModel, BaseViewHolder>
+            var localView = convertView
+            val viewHolder: BaseViewHolder?
+            val viewType = adapter.getItemViewType(position)
+            if (localView == null || localView.getTag(R.id.tag_item_type) != viewType) {
+                viewHolder = adapter.onCreateDropdownItemViewHolder(parent, viewType)
+
+                if (viewHolder != null) {
+                    localView = viewHolder.itemView
+                    localView.setTag(R.id.tag_holder, viewHolder)
+                    localView.setTag(R.id.tag_item_type, viewType)
+                }
+            } else {
+                viewHolder = localView.getTag(R.id.tag_holder) as BaseViewHolder?
+            }
+
+            viewHolder?.let { dropDownAdapter.onBindDropdownItemViewHolder(viewHolder, adapter.getItem(position), position) }
+            return localView
+        } else {
+            return getView(position, convertView, parent)
+        }
     }
 
     private inner class RecyclerViewToBaseAdapterObserver : RecyclerView.AdapterDataObserver() {

--- a/adapter/src/main/res/values/ids.xml
+++ b/adapter/src/main/res/values/ids.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="tag_item_type" type="id"/>
+    <item name="tag_holder" type="id"/>
+</resources>

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -23,4 +23,5 @@ dependencies {
     implementation project(':navigation')
     implementation project(':db')
     implementation project(':media')
+    implementation project(':adapter')
 }

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -31,7 +31,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.exo_playback_control_view.*
 import kotlinx.android.synthetic.main.fragment_audio_details.*
-import timber.log.Timber
 import kotlin.reflect.KClass
 
 /**
@@ -162,9 +161,6 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.availableTranslations
-                .doOnNext {
-                    Timber.d("Next")
-                }
                 .bindToMain(translationsAdapter.itemChanges())
                 .disposedBy(disposeBag)
 

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -2,19 +2,12 @@ package edu.artic.audio
 
 
 import android.content.ComponentName
-import android.content.Context
 import android.content.Context.BIND_AUTO_CREATE
-import android.content.Intent
 import android.content.ServiceConnection
-import android.graphics.Color
 import android.os.Bundle
 import android.os.IBinder
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.widget.ArrayAdapter
 import android.widget.Spinner
-import android.widget.TextView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.fuzz.rx.bindToMain
@@ -22,19 +15,23 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.itemSelections
 import com.jakewharton.rxbinding2.widget.text
+import edu.artic.adapter.BaseRecyclerViewAdapter
+import edu.artic.adapter.BaseViewHolder
+import edu.artic.adapter.baseRecyclerViewAdapter
+import edu.artic.adapter.itemChanges
+import edu.artic.adapter.toBaseAdapter
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.listenerAnimateSharedTransaction
 import edu.artic.base.utils.updateDetailTitle
 import edu.artic.db.models.AudioFileModel
-import edu.artic.localization.SpecifiesLanguage
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.refreshPlayBackState
 import edu.artic.viewmodel.BaseViewModelFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.rxkotlin.zipWith
 import kotlinx.android.synthetic.main.exo_playback_control_view.*
 import kotlinx.android.synthetic.main.fragment_audio_details.*
+import timber.log.Timber
 import kotlin.reflect.KClass
 
 /**
@@ -65,7 +62,9 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
     override fun hasTransparentStatusBar(): Boolean = true
     var boundService: AudioPlayerService? = null
-    private var audioIntent: Intent? = null
+
+    private val translationsAdapter: BaseRecyclerViewAdapter<AudioFileModel, BaseViewHolder>
+        get() = exo_translation_selector.adapter.baseRecyclerViewAdapter()
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceDisconnected(name: ComponentName?) {
@@ -82,8 +81,16 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 audioPlayer.player = it.player
                 it.player.refreshPlayBackState()
             }
-
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        appBarLayout.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
+            appBarLayout.updateDetailTitle(verticalOffset, expandedTitle, toolbarTitle)
+        }
+
+        exo_translation_selector.adapter = LanguageAdapter().toBaseAdapter()
     }
 
     override fun setupBindings(viewModel: AudioDetailsViewModel) {
@@ -111,10 +118,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
         }.disposedBy(disposeBag)
 
 
-
         bindTranslationSelector(viewModel)
-
-
 
         viewModel.authorCulturalPlace
                 .map { it.isNotEmpty() }
@@ -150,36 +154,40 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
     private fun bindTranslationSelector(viewModel: AudioDetailsViewModel) {
         val selectorView: Spinner = exo_translation_selector
-        viewModel.availableTranslations
-                .map {
-                    LanguageAdapter(selectorView.context, it)
-                }.zipWith(viewModel.chosenAudioModel)
+        viewModel.chosenAudioModel
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeBy { (adapter, which) ->
-                    selectorView.apply {
-                        this.adapter = adapter
-                        this.itemSelections().subscribe { position ->
-                            if (position >= 0) {
-                                val translation = adapter.getItem(position)
-                                viewModel.setTranslationOverride(translation)
-                                boundService?.switchAudioTrack(translation)
-                            }
-                        }.disposedBy(disposeBag)
-                        this.setSelection(adapter.getPosition(which))
-                    }
+                .subscribeBy { chosen ->
+                    exo_translation_selector.setSelection(translationsAdapter.itemIndexOf(chosen))
                 }
+                .disposedBy(disposeBag)
+
+        viewModel.availableTranslations
+                .doOnNext {
+                    Timber.d("Next")
+                }
+                .bindToMain(translationsAdapter.itemChanges())
                 .disposedBy(disposeBag)
 
         LanguageSelectorViewBackground(selectorView)
                 .listenToLayoutChanges()
                 .disposedBy(disposeBag)
-    }
 
+        exo_translation_selector
+                .itemSelections()
+                .subscribe { position ->
+                    if (position >= 0) {
+                        val translation = translationsAdapter.getItem(position)
+                        viewModel.setTranslationOverride(translation)
+                        boundService?.switchAudioTrack(translation)
+                    }
+                }.disposedBy(disposeBag)
+
+    }
 
     override fun onResume() {
         super.onResume()
-        audioIntent = AudioPlayerService.getLaunchIntent(requireContext())
-        requireActivity().bindService(audioIntent, serviceConnection, BIND_AUTO_CREATE)
+        requireActivity().bindService(AudioPlayerService.getLaunchIntent(requireContext()),
+                serviceConnection, BIND_AUTO_CREATE)
     }
 
     override fun onPause() {
@@ -187,61 +195,5 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
         requireActivity().unbindService(serviceConnection)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        appBarLayout.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
-            appBarLayout.updateDetailTitle(verticalOffset, expandedTitle, toolbarTitle)
-        }
-    }
 }
 
-/**
- * List adapter for the language-selection dropdown.
- *
- * This is also responsible for creating the view seen at the top
- * of the list (i.e. the 'currently selected' language).
- */
-class LanguageAdapter(context: Context, audioModels: List<AudioFileModel>) : ArrayAdapter<AudioFileModel>(
-        context,
-        R.layout.view_language_box,
-        audioModels
-) {
-    // This is a view for use in the dropdown...
-    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
-        return inflateAndBind(position, convertView, parent)
-    }
-
-    // ..and this is the one used to preview the current selection
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup): TextView {
-        val derived = inflateAndBind(position, convertView, parent)
-
-        derived.setTextColor(Color.WHITE)
-
-        return derived
-    }
-
-    /**
-     * Inflate and return a copy of `view_language_box.xml`.
-     *
-     * The inflated [TextView] will display the text of an
-     * [object which specifies its own language][SpecifiesLanguage] at the
-     * [provided index][position] within this adapter. Please refer to
-     * [SpecifiesLanguage.userFriendlyLanguage] for the expected textual output.
-     *
-     * @see ArrayAdapter.getView
-     */
-    private fun inflateAndBind(position: Int, convertView: View?, parent: ViewGroup): TextView {
-        val derived = if (convertView == null) {
-            LayoutInflater.from(parent.context)
-                    .inflate(R.layout.view_language_box, parent, false)
-        } else {
-            convertView
-        } as TextView
-
-        val item = getItem(position)
-
-        derived.text = item.userFriendlyLanguage(derived.context)
-
-        return derived
-    }
-}

--- a/audio/src/main/java/edu/artic/audio/LanguageAdapter.kt
+++ b/audio/src/main/java/edu/artic/audio/LanguageAdapter.kt
@@ -9,7 +9,10 @@ import edu.artic.db.models.AudioFileModel
 import kotlinx.android.synthetic.main.view_language_box.view.*
 
 /**
- * Description: Provides the dropdown adapter for [AudioFileModel] in an [AudioDetailsFragment].
+ * List adapter for the language-selection dropdown.
+ *
+ * This is also responsible for creating the view seen at the top
+ * of the list (i.e. the 'currently selected' language).
  */
 class LanguageAdapter : AutoHolderRecyclerViewAdapter<AudioFileModel>(),
         DropDownAdapter<AudioFileModel, BaseViewHolder> {

--- a/audio/src/main/java/edu/artic/audio/LanguageAdapter.kt
+++ b/audio/src/main/java/edu/artic/audio/LanguageAdapter.kt
@@ -1,0 +1,26 @@
+package edu.artic.audio
+
+import android.graphics.Color
+import android.view.View
+import edu.artic.adapter.AutoHolderRecyclerViewAdapter
+import edu.artic.adapter.BaseViewHolder
+import edu.artic.adapter.DropDownAdapter
+import edu.artic.db.models.AudioFileModel
+import kotlinx.android.synthetic.main.view_language_box.view.*
+
+/**
+ * Description: Provides the dropdown adapter for [AudioFileModel] in an [AudioDetailsFragment].
+ */
+class LanguageAdapter : AutoHolderRecyclerViewAdapter<AudioFileModel>(),
+        DropDownAdapter<AudioFileModel, BaseViewHolder> {
+    override fun View.onBindView(item: AudioFileModel, position: Int) {
+        text.text = item.userFriendlyLanguage(context)
+        text.setTextColor(Color.WHITE)
+    }
+
+    override fun getLayoutResId(position: Int): Int = R.layout.view_language_box
+
+    override fun View.onBindDropdownView(item: AudioFileModel, position: Int) {
+        text.text = item.userFriendlyLanguage(context)
+    }
+}

--- a/audio/src/main/res/layout/view_language_box.xml
+++ b/audio/src/main/res/layout/view_language_box.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView
+    android:id="@+id/text"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/AudioTranslationSans"


### PR DESCRIPTION
1. Add conversion methods for turning `BaseRecyclerViewAdapter` into a `BaseAdapter` via `BaseAdapterBinder`.
2. Provide `DropDownAdapter` interface mixin which gives the adapter ability to render different dropdown view than regular view.
3. Remove need for `audioIntent` from `AudioDetailsFragment`.