### PR TITLE
Update documentation around custom adapters

### DIFF
--- a/adapter/src/main/java/edu/artic/adapter/AutoHolderRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/AutoHolderRecyclerViewAdapter.kt
@@ -7,6 +7,14 @@ import android.view.ViewGroup
 /**
  * Description: Assumes the ViewHolder is a [BaseViewHolder] and then scopes the [onBindView] method
  * to the itemView of the [BaseViewHolder] to provide simplified kotlin-extensions access.
+ *
+ * Subclasses are expected to make a very clear distinction between their
+ * layouts and their binding logic:
+ *
+ * * In [getLayoutResId], check the current item at that position and return
+ *    the id of the layout needed for binding it.
+ * * In [onBindView], implement binding logic in reference to `this` (where
+ *    `this` is the inflated version of that same layout).
  */
 abstract class AutoHolderRecyclerViewAdapter<TModel> : BaseRecyclerViewAdapter<TModel, BaseViewHolder> {
 

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -6,6 +6,7 @@ import android.arch.paging.AsyncPagedListDiffer
 import android.arch.paging.PagedList
 import android.content.Context
 import android.support.annotation.LayoutRes
+import android.support.annotation.UiThread
 import android.support.v7.recyclerview.extensions.AsyncDifferConfig
 import android.support.v7.util.DiffUtil
 import android.support.v7.util.ListUpdateCallback
@@ -386,6 +387,13 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
 
     protected fun getRawPosition(itemPosition: Int) = itemPosition + headersCount
 
+    /**
+     * Dispatch point for [onClick][View.setOnClickListener] events.
+     *
+     * The 'position' integer is always that of the [BaseViewHolder] at the instant
+     * it was clicked; precise fallback logic for detached views, unusual conditions,
+     * and so forth are covered by [BaseRecyclerViewAdapter.getViewHolderPosition].
+     */
     protected open fun onItemPositionClicked(viewHolder: BaseViewHolder, position: Int) {
         getItemOrNull(position)?.let { item ->
             this.onItemClickListener?.onItemClick(position, item, viewHolder)
@@ -393,8 +401,16 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
         }
     }
 
+    /**
+     * Delegate for clicks on [this adapter's itemViews][BaseViewHolder.itemView].
+     *
+     * Always called by [onItemPositionClicked] on the UI Thread, right after
+     * [onItemClickListener?.onItemClick][OnItemClickListener.onItemClick].
+     */
+    @UiThread
     protected open fun onItemClicked(position: Int, item: TModel, viewHolder: BaseViewHolder) = Unit
 
+    @UiThread
     protected open fun onItemPositionLongClicked(viewHolder: BaseViewHolder, position: Int): Boolean {
         return getItemOrNull(position)?.let { item ->
             return@let this.onItemLongClickListener?.onItemLongPress(position, item, viewHolder)

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -346,25 +346,32 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
     fun getItemsList(): List<TModel> = pagedListAdapterHelper.currentList ?: arrayListOf()
 
     /**
+     * Variant of [getItemViewType] with the `position`
+     * parameter corrected to account for header items.
+     * Subclasses are strongly recommended to return the
+     * layout resource Id of the view instead to ensure
+     * types never clash.
+     *
+     * To specify the layout of a header or footer ViewHolder,
+     * use [addHeaderView] or [addFooterView], respectively.
+     *
      * @param position the position within the items-list dataset.
      *
-     * @return The layout associated with the [TBinding].
+     * @return The layout associated with the [TModel].
      */
     @LayoutRes
     protected abstract fun getLayoutResId(position: Int): Int
 
     /**
-     * Variant of [.getItemViewType] with the `position`
-     * parameter corrected to account for header items.
-     * Subclasses are strongly recommended to return the layout resource Id of the view instead
-     * to ensure types never clash.
+     * Determine what layout should be inflated for the [BaseViewHolder] at
+     * the given [position]. Note that the parameter is already adjusted to
+     * account for header items.
      *
-
-     * @param position index into the item list of the item whose ViewHolder type is
-     * *                 desired
-     * *
-     * @return that type
+     * Please use [getLayoutResId] instead. If two [BaseViewHolder]s possess
+     * the same layout but require different binding logic, isolate that
+     * distinction to the 3-args `onBindViewHolder(VH, TModel?, Int)`.
      */
+    @Deprecated("Implementors should not need to override this method; please migrate to 'getLayoutResId'.", ReplaceWith("getLayoutResId(position)"))
     protected open fun getViewType(position: Int) = getLayoutResId(position)
 
     protected open fun setItemClickListener(viewHolder: BaseViewHolder, onClickListener: View.OnClickListener) {

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -19,10 +19,11 @@ import java.lang.IndexOutOfBoundsException
 import java.util.ArrayList
 
 /**
- * @author Sameer Dhakal (Fuzz)
- */
-/**
- * Description: The base adapter that consolidates logic here.
+ * Description: Default implementation of [RecyclerView.Adapter].
+ *
+ * Use this class to greatly simplify integration with MVVM (that's
+ * `Model-View-ViewModel`) architectures. Main selling points are as
+ * follows:
  */
 abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
         private val diffItemCallback: DiffUtil.ItemCallback<TModel> = object :
@@ -38,12 +39,11 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
     interface OnItemClickListener<in T> {
 
         /**
-         * The item clicked.
-
-         * @param position   The position in the itemslist that was clicked.
-         * *
+         * Callback for [on-click listeners][View.setOnClickListener]. Always invoked
+         * on main thread.
+         *
+         * @param position   The position in [itemsList] that was clicked.
          * @param item       The item from the list.
-         * *
          * @param viewHolder The view holder that was clicked.
          */
         fun onItemClick(position: Int, item: T, viewHolder: BaseViewHolder)
@@ -52,12 +52,11 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
     interface OnItemLongClickListener<in T> {
 
         /**
-         * The item clicked.
-
-         * @param position   The position in the itemslist that was clicked.
-         * *
+         * Callback for [on-long-click listeners][View.setOnLongClickListener]. Always
+         * invoked on main thread.
+         *
+         * @param position   The position in [itemsList] that was clicked.
          * @param item       The item from the list.
-         * *
          * @param viewHolder The view holder that was clicked.
          *
          * @return true if view consumed the click.
@@ -67,14 +66,25 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
 
     /**
      * Interface for when headers or footers are called.
+     *
+     * One instance should be registered for the headers, and a different
+     * instance should be registered for the footers. While permitted, we
+     * do not recommend using the same callback for both types of
+     * [BaseViewHolder]s.
+     *
+     * (HF -> Header/Footer)
      */
     interface OnHFItemClickListener {
 
         /**
-         * Called when item is clicked.
-
-         * @param position   The position within the header or footers list.
-         * *
+         * Called when a header or footer item is clicked.
+         *
+         * This listener is registered with a [BaseRecyclerViewAdapter]
+         * via [onHeaderClickListener] and/or [onFooterClickListener]. Which
+         * of those two methods it is registered with determines what kind of
+         * parameters you should expect.
+         *
+         * @param position   The position within the headers/footers list.
          * @param viewHolder The view holder clicked.
          */
         fun onItemClick(position: Int, viewHolder: BaseViewHolder)

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -114,13 +114,23 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
                 AsyncDifferConfig.Builder<TModel>(diffItemCallback).build())
     }
 
+    /**
+     * Backing list of data. Update this atomically with [setItemsList].
+     */
     private var itemsList: List<TModel> = arrayListOf()
 
     private val provider = dataSourceFactory { ListDataSource(itemsList) }
 
     /**
-     * Sets an items list with 10 items. Use a [DataSource] to provide items instead to this adapter and call
-     * [setPagedList] with a [PagedList] instead for dynamically loaded content.
+     * Set up backing content for this adapter to display. Each item in the given
+     * list corresponds directly to one [BaseViewHolder].
+     *
+     * If the list is not a [PagedList], it will be split into 10-item
+     * pages for efficiency's sake.
+     *
+     * **For dynamic loading:**
+     * 1. Instantiate a [DataSource][android.arch.paging.DataSource] to provide items
+     * 2. Call [setPagedList] with a [PagedList] instead of invoking this method
      */
     @SuppressLint("RestrictedApi")
     open fun setItemsList(itemsList: List<TModel>?) {
@@ -337,7 +347,7 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
 
     /**
      * @param position the position within the items-list dataset.
-     * *
+     *
      * @return The layout associated with the [TBinding].
      */
     @LayoutRes

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -519,25 +519,20 @@ abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
         }
 
         /**
-         * If the headers and footers of a [BaseRecyclerViewAdapter] share any ids,
-         * RecyclerView.ViewPrefetcher will crash non-deterministically in
-         * [RecyclerView.Recycler.recycleViewHolderInternal].
+         * If the headers and footers of a [BaseRecyclerViewAdapter] share any
+         * ids, RecyclerView.ViewPrefetcher will crash non-deterministically
+         * in [RecyclerView.Recycler.recycleViewHolderInternal].
          *
          *
-         * To preempt that, this method throws an IllegalArgumentException as soon
-         * as a ViewHolder with such a [.getViewType] is proffered to
-         * [.addFooterHolder] or
-         * [.addHeaderHolder], which should make
-         * early detection and diagnosis of this problem much more feasible.
+         * To preempt that, this method throws an IllegalArgumentException as
+         * soon as a ViewHolder with such a [getViewType] is proffered to
+         * [addFooterHolder] or [addHeaderHolder], which should make early
+         * detection and diagnosis of this problem much more feasible.
          *
-
-         * @param forbiddenIds  a list of ids already in use. Typically [.headerLayoutIds]
-         * *                      or [.footerLayoutIds]
-         * *
+         *
+         * @param forbiddenIds  a list of ids already in use. Typically [headerLayoutIds] or [footerLayoutIds]
          * @param id            the suggested id
-         * *
-         * @param forbiddenType a name for the type of ids - this will appear in the exception
-         * *                      message
+         * @param forbiddenType a name for the type of ids - this will appear in the exception message
          */
         @JvmStatic
         protected fun preventReuseOfIdsFrom(

--- a/adapter/src/main/java/edu/artic/adapter/RXExtensions.kt
+++ b/adapter/src/main/java/edu/artic/adapter/RXExtensions.kt
@@ -8,12 +8,27 @@ import io.reactivex.functions.Consumer
 import java.util.concurrent.TimeUnit
 
 /**
- * Description:
+ * This lets you submit new changes to the adapter.
+ *
+ * Call [com.fuzz.rx.bindToMain] with this as a parameter
+ * to send new lists of items (i.e. backing data) to the
+ * adapter.
  */
 fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemChanges() = Consumer<List<TModel>> { setItemsList(it) }
 
 fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.pagedListChanges() = Consumer<PagedList<TModel>> { setPagedList(it) }
 
+/**
+ * This lets you [observe on][Observable] that gets called by
+ * [certain views][BaseViewHolder.itemView] in this adapter.
+ *
+ * Binding is set up by the default implementation of
+ * [BaseRecyclerViewAdapter.setItemClickListener], so if you
+ * override that method the events might not come through.
+ *
+ * See also [BaseRecyclerViewAdapter.onItemClickListener] and
+ * [BaseRecyclerViewAdapter.onItemClicked].
+ */
 fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemClicks(): Observable<TModel> =
         Observable.create { emitter ->
             onItemClickListener = edu.artic.adapter.onItemClickListener {
@@ -21,6 +36,12 @@ fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemClicks(): Observable<T
             }
         }
 
+/**
+ * Just like [itemClicks] - see doc on that function for more info.
+ *
+ * Please reference [BaseRecyclerViewAdapter.onItemPositionClicked] for
+ * details on the Int value used for 'position' here.
+ */
 fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemClicksWithPosition(): Observable<Pair<Int,TModel>> =
         Observable.create { emitter ->
             onItemClickListener = edu.artic.adapter.onItemClickListenerWithPosition { pos, model ->

--- a/adapter/src/main/java/edu/artic/adapter/RXExtensions.kt
+++ b/adapter/src/main/java/edu/artic/adapter/RXExtensions.kt
@@ -14,13 +14,14 @@ fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemChanges() = Consumer<L
 
 fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.pagedListChanges() = Consumer<PagedList<TModel>> { setPagedList(it) }
 
-fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemSelections(): Observable<TModel> =
+fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemClicks(): Observable<TModel> =
         Observable.create { emitter ->
             onItemClickListener = edu.artic.adapter.onItemClickListener {
                 emitter.onNext(it)
             }
         }
-fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemSelectionsWithPosition(): Observable<Pair<Int,TModel>> =
+
+fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.itemClicksWithPosition(): Observable<Pair<Int,TModel>> =
         Observable.create { emitter ->
             onItemClickListener = edu.artic.adapter.onItemClickListenerWithPosition { pos, model ->
                 emitter.onNext(pos to model)

--- a/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
@@ -11,7 +11,7 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
-import edu.artic.adapter.itemSelections
+import edu.artic.adapter.itemClicks
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.db.models.ArticObject
 import edu.artic.media.audio.AudioPlayerService
@@ -64,7 +64,7 @@ class AudioLookupFragment : BaseViewModelFragment<AudioLookupViewModel>() {
 
         number_pad.adapter = numberPadAdapter
 
-        numberPadAdapter.itemSelections()
+        numberPadAdapter.itemClicks()
                 .subscribeBy { element ->
                     viewModel.adapterClicks
                             .onNext(element)

--- a/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
+++ b/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
@@ -9,7 +9,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
 import edu.artic.analytics.ScreenCategoryName
-import edu.artic.adapter.itemSelectionsWithPosition
+import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.events.recyclerview.AllEventsItemDecoration
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
@@ -64,7 +64,7 @@ class AllEventsFragment : BaseViewModelFragment<AllEventsViewModel>() {
         viewModel.events
                 .bindToMain(adapter.itemChanges())
                 .disposedBy(disposeBag)
-        adapter.itemSelectionsWithPosition()
+        adapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickEvent(pos, model.event)
                 }

--- a/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
+++ b/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
@@ -9,7 +9,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
 import edu.artic.analytics.ScreenCategoryName
-import edu.artic.adapter.itemSelectionsWithPosition
+import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.tours.recyclerview.AllExhibitionsItemDecoration
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
@@ -51,7 +51,7 @@ class AllExhibitionsFragment : BaseViewModelFragment<AllExhibitionsViewModel>() 
                 .bindToMain(adapter.itemChanges())
                 .disposedBy(disposeBag)
 
-        adapter.itemSelectionsWithPosition()
+        adapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickExhibition(pos, model.exhibition)
                 }.disposedBy(disposeBag)

--- a/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
+++ b/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
@@ -9,7 +9,7 @@ import android.view.View
 import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
-import edu.artic.adapter.itemSelectionsWithPosition
+import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.tours.recyclerview.AllToursItemDecoration
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -64,7 +64,7 @@ class AllToursFragment : BaseViewModelFragment<AllToursViewModel>() {
 
         val adapter = recyclerView.adapter as AllToursAdapter
 
-        adapter.itemSelectionsWithPosition()
+        adapter.itemClicksWithPosition()
                 .subscribe { (pos, cell) ->
                     viewModel.onClickTour(pos, cell.tour)
                 }.disposedBy(disposeBag)

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -10,7 +10,7 @@ import com.fuzz.rx.defaultThrottle
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import edu.artic.adapter.itemChanges
-import edu.artic.adapter.itemSelectionsWithPosition
+import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.events.EventDetailFragment
 import edu.artic.exhibitions.ExhibitionDetailFragment
@@ -101,14 +101,14 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                 .disposedBy(disposeBag)
 
         val eventsAdapter = eventsRecyclerView.adapter as WelcomeEventsAdapter
-        eventsAdapter.itemSelectionsWithPosition()
+        eventsAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickEvent(pos, model.event)
                 }
                 .disposedBy(disposeBag)
 
         val onViewAdapter = onViewRecyclerView.adapter as OnViewAdapter
-        onViewAdapter.itemSelectionsWithPosition()
+        onViewAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickExhibition(pos, model.exhibition)
                 }
@@ -116,7 +116,7 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
 
 
         val toursAdapter = tourSummaryRecyclerView.adapter as WelcomeToursAdapter
-        toursAdapter.itemSelectionsWithPosition()
+        toursAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickTour(pos, model.tour)
                 }


### PR DESCRIPTION
There were some omissions in the description of these classes. Note that `BaseRecyclerViewAdapter` was added during the 'Tours Summary' PR, #4 . We'll need to update the licenses on these files as well to reflect their provenance - that shall be a separate PR, some time next week.