### PR TITLE
Add press-states to the number pad buttons (AIC-330)

### DIFF
--- a/audio/src/main/res/color/number_pad_white_tangible.xml
+++ b/audio/src/main/res/color/number_pad_white_tangible.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- In its default state, this ColorStateList is only half seen. When pressed it solidifies.-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white" android:state_pressed="true"/>
+    <item android:color="@color/number_pad_white_half_visible"/>
+</selector>

--- a/audio/src/main/res/color/number_pad_white_translucent.xml
+++ b/audio/src/main/res/color/number_pad_white_translucent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- In its default state, this ColorStateList is invisible. When pressed it appears, translucent. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/number_pad_white_half_visible" android:state_pressed="true"/>
+    <item android:color="@android:color/transparent"/>
+</selector>

--- a/audio/src/main/res/drawable/number_pad_circle.xml
+++ b/audio/src/main/res/drawable/number_pad_circle.xml
@@ -4,6 +4,7 @@
     android:shape="oval"
     android:thickness="2dp"
     >
+    <solid android:color="@color/number_pad_white_translucent"/>
     <stroke android:color="@color/number_pad_white_faint" android:width="2dp"/>
     <size
         android:width="66dp"

--- a/audio/src/main/res/drawable/number_pad_delete.xml
+++ b/audio/src/main/res/drawable/number_pad_delete.xml
@@ -9,7 +9,7 @@
 
     <path
         android:pathData="M 2,18 L 19,1 L 61,1 L 61,36 L 19,36 z"
-        android:strokeColor="@color/number_pad_white_half_visible"
+        android:strokeColor="@color/number_pad_white_tangible"
         android:strokeWidth="2"
         />
 


### PR DESCRIPTION
This uses a 50% transparency overlay for the 'numeric' and 'go' buttons.

A special dispensation is made for the 'delete back' button, which does not use an overlay. Instead, its outline brightens to a solid white when pressed.