### PR TITLE
Basic Search backend (AIC-342)

### DIFF
--- a/search/src/main/java/artic/edu/search/RetrofitSearchServiceProvider.kt
+++ b/search/src/main/java/artic/edu/search/RetrofitSearchServiceProvider.kt
@@ -1,0 +1,55 @@
+package artic.edu.search
+
+import com.fuzz.rx.bindTo
+import com.jakewharton.retrofit2.adapter.rxjava2.Result
+import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.models.ArticDataObject
+import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.Subject
+import retrofit2.Retrofit
+
+/**
+ * [Retrofit]-backed implementation of [SearchServiceProvider].
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+class RetrofitSearchServiceProvider(
+        retrofit: Retrofit,
+        dataObjectDao: ArticDataObjectDao
+) : SearchServiceProvider {
+
+
+    private val dataObject: Subject<ArticDataObject> = BehaviorSubject.create()
+
+    private val api: SearchApi = retrofit.create(SearchApi::class.java)
+
+    init {
+        dataObjectDao
+                .getDataObject()
+                .bindTo(dataObject)
+    }
+
+
+    /**
+     * Base url for query:
+     *
+     * * [ArticDataObject.dataApiUrl] + [ArticDataObject.autocompleteEndpoint]
+     *
+     * Constant query parameter (defined directly on [SearchApi.getSuggestions]):
+     *
+     * * resources="artworks,tours,exhibitions,artists"
+     */
+    override fun getSuggestions(searchQuery: String): Observable<Result<List<String>>> {
+        return dataObject.take(1)
+                .observeOn(Schedulers.io())
+                .switchMap { config ->
+                    api.getSuggestions(
+                            autoCompleteUrl = config.dataApiUrl + config.autocompleteEndpoint,
+                            searchQuery = searchQuery
+                    )
+                }
+
+    }
+}

--- a/search/src/main/java/artic/edu/search/SearchApi.kt
+++ b/search/src/main/java/artic/edu/search/SearchApi.kt
@@ -1,0 +1,30 @@
+package artic.edu.search
+
+import com.jakewharton.retrofit2.adapter.rxjava2.Result
+import io.reactivex.Observable
+import retrofit2.http.GET
+import retrofit2.http.Query
+import retrofit2.http.Url
+
+
+/**
+ * Official API endpoints for looking up search suggestions and search results.
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+interface SearchApi {
+
+
+    /**
+     * Callers should generally not need to override the default value of [resources].
+     *
+     * You'll need to derive [autoCompleteUrl] from
+     * [edu.artic.db.models.ArticDataObject.autocompleteEndpoint] at runtime.
+     */
+    @GET()
+    fun getSuggestions(
+            @Url autoCompleteUrl: String,
+            @Query("q") searchQuery: String,
+            @Query("resources") resources: String = "artworks,tours,exhibitions,artists"
+    ): Observable<Result<List<String>>>
+}

--- a/search/src/main/java/artic/edu/search/SearchFragment.kt
+++ b/search/src/main/java/artic/edu/search/SearchFragment.kt
@@ -1,7 +1,11 @@
 package artic.edu.search
 
+import com.fuzz.rx.bindTo
+import com.fuzz.rx.disposedBy
+import com.jakewharton.rxbinding2.widget.textChanges
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.viewmodel.BaseViewModelFragment
+import kotlinx.android.synthetic.main.search_app_bar_layout.view.*
 import kotlin.reflect.KClass
 
 class SearchFragment : BaseViewModelFragment<SearchViewModel>() {
@@ -19,4 +23,17 @@ class SearchFragment : BaseViewModelFragment<SearchViewModel>() {
 
     override val customToolbarColorResource: Int
         get() = R.color.greyText
+
+    override fun setupBindings(viewModel: SearchViewModel) {
+        super.setupBindings(viewModel)
+
+        toolbar!!.searchEditText
+                .textChanges()
+                .filter { it.isNotEmpty() }
+                .map { it.toString() }
+                .bindTo(viewModel.searchQuery)
+                .disposedBy(disposeBag)
+
+        // TODO: bind viewModel.searchSuggestions, viewModel.searchResults, etc.
+    }
 }

--- a/search/src/main/java/artic/edu/search/SearchModule.kt
+++ b/search/src/main/java/artic/edu/search/SearchModule.kt
@@ -3,9 +3,16 @@ package artic.edu.search
 import android.arch.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.android.ContributesAndroidInjector
 import dagger.multibindings.IntoMap
+import edu.artic.db.ApiModule
+import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.viewmodel.ViewModelKey
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import javax.inject.Named
+import javax.inject.Singleton
 
 /**
  * @author Sameer Dhakal (Fuzz)
@@ -39,4 +46,34 @@ abstract class SearchModule {
 
     @get:ContributesAndroidInjector
     abstract val searchAudioDetailFragment: SearchAudioDetailFragment
+
+
+    @Module
+    companion object {
+
+        @JvmStatic
+        @Provides
+        @Singleton
+        @Named(SEARCH_CLIENT_API)
+        fun provideClient(): OkHttpClient {
+            return OkHttpClient.Builder().build()
+        }
+
+        /**
+         * NB: We reuse the [ApiModule]'s Retrofit here.
+         *
+         * Caveats regarding its base url may apply; consult docs for
+         * [retrofit2.http.Url] before adding new API calls to [SearchApi].
+         */
+        @JvmStatic
+        @Provides
+        @Singleton
+        fun provideSearchService(
+                @Named(ApiModule.RETROFIT_BLOB_API) retrofit: Retrofit,
+                dataObjectDao: ArticDataObjectDao
+        ): SearchServiceProvider = RetrofitSearchServiceProvider(retrofit, dataObjectDao)
+
+
+        const val SEARCH_CLIENT_API = "SEARCH_CLIENT_API"
+    }
 }

--- a/search/src/main/java/artic/edu/search/SearchServiceProvider.kt
+++ b/search/src/main/java/artic/edu/search/SearchServiceProvider.kt
@@ -1,0 +1,22 @@
+package artic.edu.search
+
+import com.jakewharton.retrofit2.adapter.rxjava2.Result
+import io.reactivex.Observable
+
+
+/**
+ * Contract between a [SearchViewModel] and a [retrofit2.Retrofit]. The
+ * Retrofit contract is defined separately, in [SearchApi].
+ *
+ * Easily mocked for tests and so forth.
+ *
+ * @see edu.artic.db.AppDataServiceProvider
+ */
+interface SearchServiceProvider {
+
+    /**
+     * @see RetrofitSearchServiceProvider.getSuggestions
+     */
+    fun getSuggestions(searchQuery: String): Observable<Result<List<String>>>
+
+}

--- a/search/src/main/java/artic/edu/search/SearchViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchViewModel.kt
@@ -1,9 +1,12 @@
 package artic.edu.search
 
+import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.viewmodel.BaseViewModel
+import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import javax.inject.Inject
@@ -20,6 +23,13 @@ class SearchViewModel @Inject constructor(
     val searchResults: Subject<String> = PublishSubject.create()
 
     init {
+
+        searchQuery.observeOn(Schedulers.io())
+                .subscribeBy { query ->
+
+                    // Call searchService functions here
+
+                }.disposedBy(disposeBag)
     }
 
     fun clearText() {

--- a/search/src/main/java/artic/edu/search/SearchViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchViewModel.kt
@@ -4,9 +4,23 @@ import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.viewmodel.BaseViewModel
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
 import javax.inject.Inject
 
-class SearchViewModel @Inject constructor(private val analyticsTracker: AnalyticsTracker) : BaseViewModel() {
+class SearchViewModel @Inject constructor(
+        private val analyticsTracker: AnalyticsTracker,
+        private val searchService: SearchServiceProvider
+) : BaseViewModel() {
+
+    // Subjects for the view-layer to pick up on and hook into
+
+    val searchQuery: Subject<String> = PublishSubject.create()
+    val searchSuggestions: Subject<List<String>> = PublishSubject.create()
+    val searchResults: Subject<String> = PublishSubject.create()
+
+    init {
+    }
 
     fun clearText() {
         analyticsTracker.reportEvent(ScreenCategoryName.Search, AnalyticsAction.searchAbandoned)

--- a/search/src/main/res/layout/activity_search.xml
+++ b/search/src/main/res/layout/activity_search.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/search/src/main/res/layout/fragment_search.xml
+++ b/search/src/main/res/layout/fragment_search.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/search/src/main/res/layout/search_app_bar_layout.xml
+++ b/search/src/main/res/layout/search_app_bar_layout.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/greyText"


### PR DESCRIPTION
This adds a new `SearchApi` class, along with a `SearchServiceProvider` abstracting that away from the ViewModel.

I've left off the actual execution of the api calls and the binding of search results for now; I expect those'll need more attention so I excluded them from this PR.