### PR TITLE
Reduce duplicate RX subscriptions (AIC-349)

### DIFF
--- a/audio/src/main/AndroidManifest.xml
+++ b/audio/src/main/AndroidManifest.xml
@@ -3,8 +3,24 @@
     package="edu.artic.audio">
 
     <application>
+        <!--
+
+        This 'AudioActivity' is marked as singleTop so that
+        NarrowAudioPlayerFragment (in the 'media_ui' module)
+        can always use the same deep link logic.
+
+        When there's a NarrowAudioPlayerFragment in the
+        AudioActivity layout, this'll turn taps on that
+        fragment from '::startActivity' calls into
+        '::onNewIntent' ones. ::onNewIntent is much easier to
+        hook into the navigation graph correctly. As an added
+        bonus we avoid the need for code to make backstack
+        events work the way we want them to.
+
+        -->
         <activity
             android:name=".AudioActivity"
+            android:launchMode="singleTop"
             android:theme="@style/AppTheme.CustomToolbar.AudioTheme">
 
             <intent-filter>

--- a/audio/src/main/java/edu/artic/audio/AudioActivity.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioActivity.kt
@@ -45,6 +45,17 @@ class AudioActivity : BaseActivity() {
         }
     }
 
+    /**
+     * This catches deep links from the [NarrowAudioPlayerFragment] within this Activity.
+     *
+     * [onResume] is called just after, and that actually does the navigation.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+
+        detectDetailsScreenLink(intent)
+    }
+
     @UiThread
     private fun detectDetailsScreenLink(intent: Intent) {
         val extras: Bundle = intent.extras ?: Bundle.EMPTY
@@ -52,8 +63,8 @@ class AudioActivity : BaseActivity() {
         willNavigate = extras.getBoolean(NarrowAudioPlayerFragment.ARG_SKIP_TO_DETAILS, false)
     }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
 
         navigateToAudioDetailsScreen(supportFragmentManager)
     }

--- a/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
@@ -129,7 +129,7 @@ class AudioLookupFragment : BaseViewModelFragment<AudioLookupViewModel>() {
                             }
                         }
                     }
-                }.disposedBy(disposeBag)
+                }.disposedBy(navigationDisposeBag)
     }
 
 

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -120,17 +120,22 @@ abstract class BaseFragment : Fragment() {
     @UiThread
     private fun updateWindowProperties() {
         if (overrideStatusBarColor) {
+            // Since this is always run on UI thread, the activity and context won't
+            // change for the duration of this call.
+            val act = requireActivity()
+            val ctx = requireContext()
+
             if (hasTransparentStatusBar()) {
-                requireActivity().setWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, false)
-                requireActivity().window?.statusBarColor = Color.TRANSPARENT
+                act.setWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, false)
+                act.window?.statusBarColor = Color.TRANSPARENT
             } else {
                 if (customToolbarColorResource == 0) {
                     val primaryDarkColor = intArrayOf(android.support.design.R.attr.colorPrimaryDark)
-                    requireContext().getThemeColors(primaryDarkColor).getOrNull(0)?.defaultColor?.let {
-                        requireActivity().window?.statusBarColor = it
+                    ctx.getThemeColors(primaryDarkColor).getOrNull(0)?.defaultColor?.let {
+                        act.window?.statusBarColor = it
                     }
                 } else {
-                    requireActivity().window?.statusBarColor = ContextCompat.getColor(requireContext(), customToolbarColorResource)
+                    act.window?.statusBarColor = ContextCompat.getColor(ctx, customToolbarColorResource)
                 }
             }
         }

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -37,7 +37,15 @@ abstract class BaseFragment : Fragment() {
     val baseActivity: BaseActivity
         get() = activity as BaseActivity
 
+    /**
+     * # Lifecycle: `init{}` -> [onDestroyView]
+     *
+     * Do not add navigation observers to this; those belong in [navigationDisposeBag].
+     */
     val disposeBag = DisposeBag()
+    /**
+     * # Lifecycle: [onResume] -> [onPause]
+     */
     val navigationDisposeBag = DisposeBag()
 
     protected fun requireView() = view

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -3,6 +3,7 @@ package edu.artic.ui
 import android.graphics.Color
 import android.os.Bundle
 import android.support.annotation.LayoutRes
+import android.support.annotation.UiThread
 import android.support.design.widget.CollapsingToolbarLayout
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
@@ -92,6 +93,7 @@ abstract class BaseFragment : Fragment() {
 
     protected open fun hasHomeAsUpEnabled(): Boolean = true
 
+    @UiThread
     private fun updateToolbar(view: View) {
         toolbar = view.findViewById(R.id.toolbar)
         if (toolbar != null) {
@@ -112,6 +114,11 @@ abstract class BaseFragment : Fragment() {
             setExpandedTitleTypeface(toolbarTextTypeFace)
         }
 
+        updateWindowProperties()
+    }
+
+    @UiThread
+    private fun updateWindowProperties() {
         if (overrideStatusBarColor) {
             if (hasTransparentStatusBar()) {
                 requireActivity().setWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, false)

--- a/viewmodel/src/main/kotlin/edu/artic/viewmodel/BaseViewModelFragment.kt
+++ b/viewmodel/src/main/kotlin/edu/artic/viewmodel/BaseViewModelFragment.kt
@@ -102,5 +102,10 @@ abstract class BaseViewModelFragment<TViewModel : BaseViewModel> : BaseFragment(
 
     protected open fun setupBindings(viewModel: TViewModel) = Unit
 
+    /**
+     * # Remember to dispose your nav bindings with [navigationDisposeBag], not [disposeBag].
+     *
+     * @see NavViewViewModel
+     */
     protected open fun setupNavigationBindings(viewModel: TViewModel) = Unit
 }

--- a/viewmodel/src/main/kotlin/edu/artic/viewmodel/BaseViewModelFragment.kt
+++ b/viewmodel/src/main/kotlin/edu/artic/viewmodel/BaseViewModelFragment.kt
@@ -64,6 +64,8 @@ abstract class BaseViewModelFragment<TViewModel : BaseViewModel> : BaseFragment(
     override fun onResume() {
         super.onResume()
         if (isViewJustCreated) {
+            // Without this assignment, the screen will flicker (whether it's noticeable depends on the subclass)
+            isViewJustCreated = false
             setupBindings(viewModel)
         }
         setupNavigationBindings(viewModel)

--- a/viewmodel/src/main/kotlin/edu/artic/viewmodel/NavViewViewModel.kt
+++ b/viewmodel/src/main/kotlin/edu/artic/viewmodel/NavViewViewModel.kt
@@ -5,5 +5,15 @@ import io.reactivex.subjects.Subject
 
 open class NavViewViewModel<T> : BaseViewModel() {
 
+    /**
+     * # Very important:
+     *
+     * If this field is observed in a [BaseViewModelFragment.setupNavigationBindings],
+     * you'd better dispose it with [BaseViewModelFragment.navigationDisposeBag].
+     *
+     * Exceptions to this rule may be permitted on a case by case basis. **Failure
+     * to comply may result in duplicate navigation events (and thus 'id not found'
+     * crashes)**
+     */
     val navigateTo: Subject<Navigate<T>> = PublishSubject.create<Navigate<T>>()
 }


### PR DESCRIPTION
This is intended to resolve some visual problems and some (at first glance inconsistent) behavior.

Sample issue: navigate in the following pattern:

1. Hit 'audio'
2. Hit 'home' (do NOT use the back button)
3. Hit 'audio'
3a. Each button press on the number pad will be registered twice.
3b. This includes the 'Go' button - we can go only once, and the second invocation triggers a crash

Each subsequent load of the 'audio' screen in the same manner as steps 1. and 2. will register an extra subscription and cause more trouble. The number of duplicate button presses is capped at 5 but the subscription count is unlimited.

Work done in this branch:

*    Document navigationDisposeBag in the code itself
*    Restrict standard binding to one resume per create-destroy lifecycle
*    Run `Window.setStatusBarColor` earlier than currently-done (c.f. comments added in 9c408030411d3e7646b73d0)
*    Prevent duplicate launches of `AudioActivity` that were causing duplicate fragments to register duplicate on-click observers and duplicate on-navigate observers

