### PR TITLE
Ignore duplicate clicks on bottom nav (AIC-363)

### DIFF
--- a/audio/src/main/java/edu/artic/audio/AudioActivity.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.annotation.UiThread
 import android.support.v4.app.FragmentManager
 import edu.artic.base.utils.disableShiftMode
+import edu.artic.base.utils.preventReselection
 import edu.artic.media.ui.NarrowAudioPlayerFragment
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.ui.BaseActivity
@@ -41,6 +42,7 @@ class AudioActivity : BaseActivity() {
         bottomNavigation.apply {
             disableShiftMode(R.color.audio_menu_color_list)
             selectedItemId = R.id.action_audio
+            preventReselection()
             setOnNavigationItemSelectedListener(NavigationSelectListener(this.context))
         }
     }

--- a/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
@@ -5,10 +5,9 @@ import android.support.design.internal.BottomNavigationItemView
 import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
 import android.support.v4.content.ContextCompat
+import android.view.MenuItem
 
-/**
- * @author Sameer Dhakal (Fuzz)
- */
+
 
 /**
  * This hack is required for displaying title below icon.
@@ -37,4 +36,23 @@ fun BottomNavigationView.disableShiftMode(colorList: Int = 0) {
             }
         }
     }
+}
+
+/**
+ * Special implementation of [BottomNavigationView.OnNavigationItemReselectedListener]
+ * with absolutely no state and no action. Set it on a view with [preventReselection].
+ */
+private object IgnoreReselection : BottomNavigationView.OnNavigationItemReselectedListener {
+    // No need to do anything in the method body.
+    override fun onNavigationItemReselected(item: MenuItem) = Unit
+}
+
+/**
+ * Disable on-click events for highlighted items.
+ *
+ * See [BottomNavigationView.setOnNavigationItemReselectedListener] for
+ * details.
+ */
+fun BottomNavigationView.preventReselection() {
+    setOnNavigationItemReselectedListener(IgnoreReselection)
 }

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -3,6 +3,7 @@ package edu.artic.info
 import android.os.Bundle
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.base.utils.disableShiftMode
+import edu.artic.base.utils.preventReselection
 import edu.artic.ui.BaseActivity
 import kotlinx.android.synthetic.main.activity_info.*
 
@@ -16,6 +17,7 @@ class InfoActivity : BaseActivity() {
         bottomNavigation.apply {
             disableShiftMode(R.color.info_menu_color_list)
             selectedItemId = R.id.action_info
+            preventReselection()
             setOnNavigationItemSelectedListener(NavigationSelectListener(this.context))
         }
     }

--- a/map/src/main/kotlin/edu/artic/map/MapActivity.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapActivity.kt
@@ -6,6 +6,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.MemoryCategory
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.disableShiftMode
+import edu.artic.base.utils.preventReselection
 import edu.artic.db.models.ArticTour
 import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationSelectListener
@@ -46,6 +47,7 @@ class MapActivity : BaseActivity() {
         bottomNavigation.apply {
             disableShiftMode(R.color.map_menu_color_list)
             selectedItemId = R.id.action_map
+            preventReselection()
             setOnNavigationItemSelectedListener(NavigationSelectListener(this.context))
         }
     }

--- a/navigation/src/main/java/edu/artic/navigation/NavigationSelectListener.kt
+++ b/navigation/src/main/java/edu/artic/navigation/NavigationSelectListener.kt
@@ -9,8 +9,13 @@ import edu.artic.base.utils.asDeepLinkIntent
 
 
 /**
- * {@link BottomNavigationView.OnNavigationItemSelectedListener} Implementation for app.
+ * [BottomNavigationView.OnNavigationItemSelectedListener] Implementation for the app.
+ *
+ * Makes use of [NavigationConstants] and [asDeepLinkIntent] to launch other modules
+ * without needing to know [precisely what would be loaded][android.content.ComponentName].
+ *
  * @author Sameer Dhakal (Fuzz)
+ * @see edu.artic.base.utils.preventReselection
  */
 class NavigationSelectListener(val context: Context) : BottomNavigationView.OnNavigationItemSelectedListener {
     override fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.navigation.Navigation
 import edu.artic.base.utils.disableShiftMode
+import edu.artic.base.utils.preventReselection
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.ui.BaseActivity
 import kotlinx.android.synthetic.main.activity_welcome.*
@@ -33,6 +34,7 @@ class WelcomeActivity : BaseActivity() {
         }
         bottomNavigation.disableShiftMode(R.color.menu_color_list)
         bottomNavigation.selectedItemId = R.id.action_home
+        bottomNavigation.preventReselection()
         bottomNavigation.setOnNavigationItemSelectedListener(NavigationSelectListener(this))
     }
 

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
@@ -32,10 +32,13 @@ class WelcomeActivity : BaseActivity() {
             finish()
             return
         }
-        bottomNavigation.disableShiftMode(R.color.menu_color_list)
-        bottomNavigation.selectedItemId = R.id.action_home
-        bottomNavigation.preventReselection()
-        bottomNavigation.setOnNavigationItemSelectedListener(NavigationSelectListener(this))
+
+        bottomNavigation.apply {
+            disableShiftMode(R.color.menu_color_list)
+            selectedItemId = R.id.action_home
+            preventReselection()
+            setOnNavigationItemSelectedListener(NavigationSelectListener(this@WelcomeActivity))
+        }
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
This is a followup to #100. I noticed that we go through a wasteful `pause`-`resume` cycle whenever the icon for the current section of the app is tapped.

In addition, such intents overwrite the original launch intent and unnecessarily encumber diagnosis of navigation graph issues. This PR includes the logic needed to `preventReselection()` - see inline documentation for more details.