### PR TITLE
Tour language must persist (AIC-355)

### DIFF
--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -154,7 +154,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
 
     private fun bindTranslationSelector(viewModel: AudioDetailsViewModel) {
-        val selectorView: Spinner = exo_translation_selector
+
         viewModel.chosenAudioModel
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { chosen ->
@@ -166,7 +166,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 .bindToMain(translationsAdapter.itemChanges())
                 .disposedBy(disposeBag)
 
-        LanguageSelectorViewBackground(selectorView)
+        LanguageSelectorViewBackground(exo_translation_selector)
                 .listenToLayoutChanges()
                 .disposedBy(disposeBag)
 

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
@@ -83,8 +83,8 @@ class AudioDetailsViewModel @Inject constructor(val languageSelector: LanguageSe
 
         // Set up the default language selection.
         known.map {
-            // TODO: we'll need to modify this to account for the current Tour language
-            languageSelector.selectFrom(it)
+            // TODO: inject 'edu.artic.map.carousel.TourProgressManager', use that state as boolean
+            languageSelector.selectFrom(it, true)
         }.bindTo(chosenAudioModel)
                 .disposedBy(disposeBag)
 

--- a/localization/src/main/kotlin/edu/artic/localization/LocalizationPreferences.kt
+++ b/localization/src/main/kotlin/edu/artic/localization/LocalizationPreferences.kt
@@ -28,17 +28,21 @@ class LocalizationPreferences(context: Context)
                 Locale.getDefault().toLanguageTag()
         )).orFallback()
 
+    private var innerTourLocale: String? = null
+
+    /**
+     * Public access to the current tour language.
+     *
+     * Internally managed via [innerTourLocale].
+     */
     var tourLocale: Locale
         set(given) {
-            putString(
-                    PREF_TOUR_LOCALE,
-                    given.toLanguageTag()
-            )
+            innerTourLocale = given.toLanguageTag()
         }
-        get() = Locale.forLanguageTag(getString(
-                PREF_TOUR_LOCALE,
+        get() = Locale.forLanguageTag(
+                innerTourLocale ?:
                 Locale.getDefault().toLanguageTag()
-        )).orFallback(preferredAppLocale)
+        ).orFallback(preferredAppLocale)
 }
 
 /**

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -376,7 +376,8 @@ class AudioPlayerService : DaggerService() {
                 pausePlayer()
                 playPlayer(it, alternative)
             } else {
-                currentTrack.onNext(alternative)
+                playPlayer(it, alternative)
+                pausePlayer()
             }
         }
     }

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -190,7 +190,7 @@ class AudioPlayerService : DaggerService() {
         audioControl.subscribe { playBackAction ->
             when (playBackAction) {
                 is PlayBackAction.Play -> {
-                    player.seekTo(0)
+                    // No need to seek here; that'll be done in 'setArticObject' if needed
                     setArticObject(playBackAction.audioFile, playBackAction.audioModel)
                     player.playWhenReady = true
                 }


### PR DESCRIPTION
When you visit the audio details page after starting a tour in a different language, the audio file will switch back to the app language. This is a problem.