### PR TITLE
Refactor and leave tour dialog design update

### DIFF
--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -20,9 +20,9 @@
     <string name="credits">Credits</string>
     <string name="name_of_this_language">English</string>
     <string name="tour_argument_key" translatable="false">tour</string>
-    <string name="leaveTour">Leave Current Tour</string>
+    <string name="leaveCurrentTour">Leave Current Tour</string>
     <string name="stay">Stay</string>
-    <string name="leave">Leave</string>
+    <string name="leaveTour">Leave Tour</string>
     <string name="searchContent">Search Content</string>
     <string name="looking_for_artwork">Looking for Artwork?</string>
     <string name="suggested">Suggested</string>

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -51,7 +51,7 @@ import kotlin.reflect.KClass
  *
  * @see [MapActivity]
  */
-class MapFragment : BaseViewModelFragment<MapViewModel>(), LeaveCurrentTourDialogFragment.LeaveTourCallback {
+class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
     override val viewModelClass: KClass<MapViewModel>
         get() = MapViewModel::class
@@ -421,7 +421,16 @@ class MapFragment : BaseViewModelFragment<MapViewModel>(), LeaveCurrentTourDialo
         leaveTourDialog?.dismiss()
         val fm = requireFragmentManager()
         leaveTourDialog = LeaveCurrentTourDialogFragment().apply {
-            attachTourStateListener(this@MapFragment)
+            attachTourStateListener(object: LeaveCurrentTourDialogFragment.LeaveTourCallback{
+                override fun leftTour() {
+                    viewModel.leaveCurrentTour()
+                }
+
+                override fun stayed() {
+                    viewModel.stayedWithCurrentTour()
+                }
+
+            })
             this.show(fm, "LeaveTour")
         }
 
@@ -430,21 +439,6 @@ class MapFragment : BaseViewModelFragment<MapViewModel>(), LeaveCurrentTourDialo
     private fun refreshMapDisplayMode(requestedTour: ArticTour? = null, requestedStop: ArticTour.TourStop? = null) {
         viewModel.loadMapDisplayMode(requestedTour, requestedStop)
     }
-
-    /**
-     * User leaves tour.
-     */
-    override fun leftTour() {
-        viewModel.leaveCurrentTour()
-    }
-
-    /**
-     * Stays decides to stay on active tour.
-     */
-    override fun stayed() {
-        viewModel.stayedWithCurrentTour()
-    }
-
 
     override fun onStart() {
         super.onStart()

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -427,7 +427,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 }
 
                 override fun stayed() {
-                    viewModel.stayedWithCurrentTour()
+                    viewModel.stayWithCurrentTour()
                 }
 
             })

--- a/map/src/main/kotlin/edu/artic/map/MapModule.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapModule.kt
@@ -6,9 +6,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
 import dagger.multibindings.IntoMap
-import edu.artic.map.carousel.TourCarouselFragment
-import edu.artic.map.carousel.TourCarouselViewModel
-import edu.artic.map.carousel.TourProgressManager
+import edu.artic.map.carousel.*
 import edu.artic.viewmodel.ViewModelKey
 import javax.inject.Singleton
 
@@ -45,6 +43,9 @@ abstract class MapModule {
 
     @get:ContributesAndroidInjector
     abstract val searchObjectDetailsFragment: SearchObjectDetailsFragment
+
+    @get:ContributesAndroidInjector
+    abstract val leaveCurrentTourDialogFragment: LeaveCurrentTourDialogFragment
 
     @get:ContributesAndroidInjector
     abstract val tourCarouselFragment: TourCarouselFragment

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -233,9 +233,9 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                 tourProgressManager.proposedTour,
                 searchManager.selectedObject)
                 .take(1)
-                .subscribeBy { (lastTour, nextTour, lastSearchedObject) ->
+                .subscribeBy { (currentTour, nextTour, lastSearchedObject) ->
                     val searchObject = lastSearchedObject.value
-                    val activeTour = lastTour.value
+                    val activeTour = currentTour.value
                     val proposedTour  = nextTour.value
 
                     if (searchObject != null && requestedTour == null) {

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -236,6 +236,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                 .subscribeBy { (lastTour, nextTour, lastSearchedObject) ->
                     val searchObject = lastSearchedObject.value
                     val activeTour = lastTour.value
+                    val proposedTour  = nextTour.value
 
                     if (searchObject != null && requestedTour == null) {
                         /**
@@ -253,9 +254,8 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                         searchManager.selectedObject.onNext(Optional(null))
                         val startStop = requestedTourStop ?: activeTour.getIntroStop()
                         switchTourRequest.onNext(requestedTour to startStop)
-                    } else if (nextTour.value != null) {
-                        val tour = nextTour.value!!.first
-                        val stop = nextTour.value!!.second
+                    } else if (proposedTour != null) {
+                        val (tour, stop) = proposedTour
                         displayModeChanged(MapDisplayMode.Tour(tour, stop))
                         tourProgressManager.nextTour.onNext(Optional(null))
                     } else {

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -279,6 +279,11 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         /**
          * Store the search object to memory.
          * Used in [MapViewModel.loadMapDisplayMode] to determine the map display mode.
+         *
+         * When the map gets a searchedObject, it saves searchedObject to
+         * [SearchManager.selectedObject] until is cleared out from [SearchManager].
+         * If the searchedObject is null we discard it as if there was no search request
+         * and fetch cached data from [SearchManager.selectedObject].
          */
         searchedObject?.let {
             searchManager.selectedObject.onNext(Optional(searchedObject))

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -327,8 +327,10 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     /**
      * User stays with current tour.
      * Clear out cached search object if any.
+     * Clear out purposed tour.
      */
     fun stayWithCurrentTour() {
         searchManager.selectedObject.onNext(Optional(null))
+        tourProgressManager.proposedTour.onNext(Optional(null))
     }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -124,7 +124,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
          */
         switchTourRequest
                 .mapOptional()
-                .bindTo(tourProgressManager.nextTour)
+                .bindTo(tourProgressManager.proposedTour)
                 .disposedBy(disposeBag)
     }
 
@@ -230,7 +230,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     fun loadMapDisplayMode(requestedTour: ArticTour?, requestedTourStop: ArticTour.TourStop?) {
         Observables.combineLatest(
                 tourProgressManager.selectedTour,
-                tourProgressManager.nextTour,
+                tourProgressManager.proposedTour,
                 searchManager.selectedObject)
                 .take(1)
                 .subscribeBy { (lastTour, nextTour, lastSearchedObject) ->
@@ -257,7 +257,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                     } else if (proposedTour != null) {
                         val (tour, stop) = proposedTour
                         displayModeChanged(MapDisplayMode.Tour(tour, stop))
-                        tourProgressManager.nextTour.onNext(Optional(null))
+                        tourProgressManager.proposedTour.onNext(Optional(null))
                     } else {
                         searchManager.selectedObject.onNext(Optional(null))
                         val tourToLoad = requestedTour ?: activeTour

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -328,7 +328,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
      * User stays with current tour.
      * Clear out cached search object if any.
      */
-    fun stayedWithCurrentTour() {
+    fun stayWithCurrentTour() {
         searchManager.selectedObject.onNext(Optional(null))
     }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -309,7 +309,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         /**
          * Clear selected tour language.
          */
-        languageSelector.setTourLanguage(Locale(""))
+        languageSelector.setTourLanguage(Locale.ROOT)
 
         /**
          * Finally, clear out the tour object from memory.

--- a/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
@@ -1,0 +1,63 @@
+package edu.artic.map.carousel
+
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.View
+import com.fuzz.rx.defaultThrottle
+import com.fuzz.rx.disposedBy
+import com.jakewharton.rxbinding2.view.clicks
+import edu.artic.analytics.ScreenCategoryName
+import edu.artic.map.R
+import edu.artic.ui.BaseFragment
+import io.reactivex.rxkotlin.subscribeBy
+import kotlinx.android.synthetic.main.fragment_leave_tour_dialog.*
+
+/**
+ * @author Sameer Dhakal (Fuzz)
+ */
+class LeaveCurrentTourDialogFragment : BaseFragment() {
+
+    private var callback: LeaveTourCallback? = null
+
+    fun attachTourStateListener(listener: LeaveTourCallback) {
+        callback = listener
+    }
+
+    override val title: String
+        get() = ""
+
+    override val screenCategory: ScreenCategoryName?
+        get() = null
+
+    override val layoutResId: Int = R.layout.fragment_leave_tour_dialog
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(DialogFragment.STYLE_NO_TITLE, R.style.LeaveTourDialogTheme)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        leave.clicks()
+                .defaultThrottle()
+                .subscribeBy {
+                    dismiss()
+                    callback?.leftTour()
+                }
+                .disposedBy(disposeBag)
+
+        stay.clicks()
+                .defaultThrottle()
+                .subscribeBy {
+                    dismiss()
+                    callback?.stayed()
+                }
+                .disposedBy(disposeBag)
+    }
+
+    interface LeaveTourCallback {
+        fun leftTour()
+        fun stayed()
+    }
+
+}

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourProgressManager.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourProgressManager.kt
@@ -20,6 +20,6 @@ class TourProgressManager {
      * Save the last selected tour.
      */
     val selectedTour: Subject<Optional<ArticTour>> = BehaviorSubject.createDefault(Optional(null))
-    val nextTour: Subject<Optional<Pair<ArticTour, ArticTour.TourStop>>> = BehaviorSubject.createDefault(Optional(null))
+    val proposedTour: Subject<Optional<Pair<ArticTour, ArticTour.TourStop>>> = BehaviorSubject.createDefault(Optional(null))
     val leaveTourRequest: Subject<Boolean> = PublishSubject.create()
 }

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourProgressManager.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourProgressManager.kt
@@ -20,6 +20,6 @@ class TourProgressManager {
      * Save the last selected tour.
      */
     val selectedTour: Subject<Optional<ArticTour>> = BehaviorSubject.createDefault(Optional(null))
-
+    val nextTour: Subject<Optional<Pair<ArticTour, ArticTour.TourStop>>> = BehaviorSubject.createDefault(Optional(null))
     val leaveTourRequest: Subject<Boolean> = PublishSubject.create()
 }

--- a/map/src/main/res/layout/fragment_leave_tour_dialog.xml
+++ b/map/src/main/res/layout/fragment_leave_tour_dialog.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/off_blue">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/SectionTitleWhite"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/marginTriple"
+        android:layout_marginBottom="@dimen/leave_tour_title_button_padding"
+        android:fontFamily="@font/ideal_sans_book"
+        android:gravity="center"
+        android:text="Leave Current Tour?"
+        app:layout_constraintBottom_toTopOf="@id/stay"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0" />
+
+    <Button
+        android:id="@+id/stay"
+        style="@style/DialogButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginTriple"
+        android:layout_marginBottom="@dimen/marginTwenty"
+        android:gravity="start|center"
+        android:text="@string/stay"
+        android:textAllCaps="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/leave"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title" />
+
+    <Button
+        android:id="@+id/leave"
+        style="@style/DialogButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/marginTriple"
+        android:gravity="end|center"
+        android:text="@string/leaveTour"
+        android:textAllCaps="true"
+        app:layout_constraintBottom_toBottomOf="@id/stay"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/stay"
+        app:layout_constraintTop_toTopOf="@id/stay" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/map/src/main/res/values/dimens.xml
+++ b/map/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="artic_object_map_image_size">49dp</dimen>
+    <dimen name="leave_tour_title_button_padding">120dp</dimen>
 </resources>

--- a/map/src/main/res/values/styles.xml
+++ b/map/src/main/res/values/styles.xml
@@ -30,4 +30,13 @@
     <style name="MyButton" parent="Widget.AppCompat.Button">
         <item name="android:textAllCaps">false</item>
     </style>
+
+    <style name="DialogButton">
+        <item name="android:fontFamily">@font/ideal_sans_medium</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:background">@null</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:minHeight">50dp</item>
+    </style>
 </resources>

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.annotation.LayoutRes
 import android.support.annotation.UiThread
 import android.support.design.widget.CollapsingToolbarLayout
+import android.support.v4.app.DialogFragment
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
 import android.support.v4.content.res.ResourcesCompat
@@ -20,7 +21,7 @@ import edu.artic.base.utils.setWindowFlag
 import timber.log.Timber
 import javax.inject.Inject
 
-abstract class BaseFragment : Fragment() {
+abstract class BaseFragment : DialogFragment() {
 
     var toolbar: Toolbar? = null
     var collapsingToolbar: CollapsingToolbarLayout? = null


### PR DESCRIPTION
Changes:
* Updates leave tour dialog design
* Refactors leave tour dialog to use DialogFragment instead of AlertDialog 
* Adds `next tour` in tour progress manager for queuing the requested tour (it will be displayed if the user leaves active tour)