### PR TITLE
Minor splash improvements (AIC-380)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataState.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataState.kt
@@ -1,6 +1,10 @@
 package edu.artic.db
 
 sealed class ProgressDataState {
+    /**
+     * Use this for serious exceptions, like [java.io.IOException] or [IllegalStateException].
+     */
+    class Interrupted(val error: Throwable) : ProgressDataState()
     class Downloading(val progress: Float) : ProgressDataState()
     class Done<T>(val result: T, val headers: Map<String, List<String>> = mapOf()) : ProgressDataState()
     object Empty : ProgressDataState()

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -6,6 +6,7 @@ import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ArticDataObject
 import edu.artic.db.progress.ProgressEventBus
 import io.reactivex.Observable
+import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import retrofit2.Retrofit
@@ -82,7 +83,9 @@ class RetrofitAppDataServiceProvider(
 
     override fun getExhibitions(): Observable<ProgressDataState> {
         return Observable.create { observer ->
-            dataObject.subscribe { dataObject ->
+            dataObject.subscribeBy(
+                    onError = { observer.onError(it) },
+                    onNext = { dataObject ->
                 var url = dataObject.dataApiUrl + dataObject.exhibitionsEndpoint
                 if (!url.contains("/search")) {
                     url += "/search"
@@ -113,7 +116,7 @@ class RetrofitAppDataServiceProvider(
                         }
 
                         )
-            }
+            })
         }
 
     }
@@ -121,7 +124,9 @@ class RetrofitAppDataServiceProvider(
 
     override fun getEvents(): Observable<ProgressDataState> {
         return Observable.create { observer ->
-            dataObject.subscribe { dataObject ->
+            dataObject.subscribeBy(
+                    onError = { observer.onError(it) },
+                    onNext = { dataObject ->
                 var url = dataObject.dataApiUrl + dataObject.eventsEndpoint
                 if (!url.contains("/search")) {
                     url += "/search"
@@ -149,7 +154,7 @@ class RetrofitAppDataServiceProvider(
                         }
 
                         )
-            }
+            })
         }
     }
 

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -24,6 +24,9 @@ class SplashActivity : BaseViewModelActivity<SplashViewModel>() {
                 .map {
                     "Percentage : %.2f".format(it * 100)
                 }
+                .onErrorReturn {
+                    it.localizedMessage
+                }
                 .bindToMain(percentText.text())
                 .disposedBy(disposeBag)
     }

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -21,7 +21,9 @@ class SplashActivity : BaseViewModelActivity<SplashViewModel>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.percentage
-                .map { "Percentage : ${it * 100}" }
+                .map {
+                    "Percentage : %.2f".format(it * 100)
+                }
                 .bindToMain(percentText.text())
                 .disposedBy(disposeBag)
     }

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -1,6 +1,5 @@
 package edu.artic.splash
 
-import android.util.Log
 import com.fuzz.rx.asObservable
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
@@ -25,6 +24,9 @@ class SplashViewModel @Inject constructor(appDataManager: AppDataManager) : NavV
         appDataManager.loadData()
                 .subscribe({
                     when (it) {
+                        is ProgressDataState.Interrupted -> {
+                            percentage.onError(it.error)
+                        }
                         is ProgressDataState.Downloading -> {
                             percentage.onNext(it.progress)
                         }
@@ -36,7 +38,7 @@ class SplashViewModel @Inject constructor(appDataManager: AppDataManager) : NavV
                         }
                     }
                 }, {
-                    it.printStackTrace()
+                    percentage.onError(it)
                 }, {}).disposedBy(disposeBag)
     }
 

--- a/splash/src/main/res/layout/activity_splash.xml
+++ b/splash/src/main/res/layout/activity_splash.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
 
     <TextView
         android:id="@+id/percentText"
+        style="@style/CardTitleLargeBlack"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
+        android:maxLines="6"
         tools:text="100%"
         />
 


### PR DESCRIPTION
I know that we've got a much nicer splash screen planned out. Nevertheless, I felt there were some minor improvements we could make now without significant churn. Additionally, we will need the load-level error handling logic no matter what kind of splash screen we end up displaying.

* Progress percentage is fixed-width
* Errors thrown during load are shown in place of progress text and do not crash app
* Progress text is larger font size and black instead of grey for heightened contrast

NB: only the first error will appear on screen. I feel this is acceptable for now.