### PR TITLE
Display search items in map

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/daos/ArticMapAnnotationDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticMapAnnotationDao.kt
@@ -36,4 +36,11 @@ abstract class ArticMapAnnotationDao {
     fun getAmenitiesOnMapForFloor(floor: String): Flowable<List<ArticMapAnnotation>> = getAnnotationByTypeForFloor(ArticMapAnnotationType.AMENITY, floor)
 
     fun getDepartmentOnMapForFloor(floor: String): Flowable<List<ArticMapAnnotation>> = getAnnotationByTypeForFloor(ArticMapAnnotationType.DEPARTMENT, floor)
+
+    @Query("select * from ArticMapAnnotation where amenityType in (:amenityType) and floor = :floor")
+    abstract fun getAmenitiesByAmenityType(amenityType: List<String>, floor: String): Flowable<List<ArticMapAnnotation>>
+
+    @Query("select * from ArticMapAnnotation where amenityType in (:amenityType)")
+    abstract fun getAmenitiesByAmenityType(amenityType: List<String>): Flowable<List<ArticMapAnnotation>>
+
 }

--- a/db/src/main/kotlin/edu/artic/db/models/ArticMapAnnotation.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticMapAnnotation.kt
@@ -61,7 +61,7 @@ class ArticMapAmenityType {
         const val WOMANS_ROOM = "Women's Room"
         const val MENS_ROOM = "Men's Room"
         const val ELEVATOR = "Elevator"
-        const val GIFT_SHOP= "Gift Shop"
+        const val GIFT_SHOP = "Gift Shop"
         const val TICKETS = "Tickets"
         const val INFORMATION = "Information"
         const val CHECK_ROOM = "Check Room"
@@ -70,5 +70,17 @@ class ArticMapAmenityType {
         const val DINING = "Dining"
         const val FAMILY_RESTROOM = "Family Restroom"
         const val MEMBERS_LOUNGE = "Members Lounge"
+
+        const val RESTROOMS = "Restrooms"
+
+        fun getAmenityTypes(item: String): List<String> {
+            return if (item == ArticMapAmenityType.RESTROOMS) {
+                listOf(ArticMapAmenityType.MENS_ROOM, ArticMapAmenityType.WOMANS_ROOM, ArticMapAmenityType.FAMILY_RESTROOM)
+            } else {
+                listOf(item)
+            }
+        }
+
     }
 }
+

--- a/db/src/main/kotlin/edu/artic/db/models/ArticMapAnnotation.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticMapAnnotation.kt
@@ -4,6 +4,7 @@ import android.arch.persistence.room.Entity
 import android.arch.persistence.room.PrimaryKey
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import edu.artic.db.Floor
 import edu.artic.ui.util.asCDNUri
 
 @JsonClass(generateAdapter = true)
@@ -17,7 +18,7 @@ data class ArticMapAnnotation(
         @Json(name = "location") val location: String?,
         @Json(name = "latitude") val latitude: String?,
         @Json(name = "longitude") val longitude: String?,
-        @Json(name = "floor") val floor: String?,
+        @Floor @Json(name = "floor") val floor: Int?,
         @Json(name = "description") val description: String?,
         @Json(name = "label") val label: String?,
         @Json(name = "annotation_type") val annotationType: String?,

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsViewModel.kt
@@ -173,5 +173,6 @@ class TourDetailsStopCellViewModel(tourStop: ArticTour.TourStop, objectDao: Arti
                 .filter { it.galleryLocation != null }
                 .map { it.galleryLocation!! }
                 .bindTo(galleryText)
+                .disposedBy(disposeBag)
     }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
@@ -50,5 +50,8 @@ internal fun ZoomLevel.toMapFocus(): MapFocus = when {
 sealed class MapDisplayMode {
     data class Tour(val tour: ArticTour, val selectedTourStop: ArticTour.TourStop?) : MapDisplayMode()
     object CurrentFloor : MapDisplayMode()
-    data class Search<T>(val item: T) : MapDisplayMode()
+    sealed class Search<T>(val item: T) : MapDisplayMode() {
+        class ObjectSearch(item: ArticObject) : Search<ArticObject>(item)
+        class AmenitiesSearch(amenityType: String) : Search<String>(amenityType)
+    }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -30,6 +30,7 @@ import edu.artic.map.rendering.MapItemRenderer
 import edu.artic.map.rendering.MarkerMetaData
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.ui.getAudioServiceObservable
+import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
 import edu.artic.navigation.NavigationConstants.Companion.ARG_SEARCH_OBJECT
 import edu.artic.viewmodel.BaseViewModelFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -71,6 +72,12 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
     private fun getLatestSearchObject(): ArticObject? {
         return requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
+    }
+
+    private fun getLatestSearchObjectType(): String? {
+        val data: String? = requireActivity().intent?.getStringExtra(ARG_AMENITY_TYPE)
+        requireActivity().intent?.removeExtra(ARG_AMENITY_TYPE)
+        return data
     }
 
     private fun getLatestTourObject(): ArticTour? {
@@ -411,7 +418,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
         leaveTourDialog?.dismiss()
         val fm = requireFragmentManager()
         leaveTourDialog = LeaveCurrentTourDialogFragment().apply {
-            attachTourStateListener(object: LeaveCurrentTourDialogFragment.LeaveTourCallback{
+            attachTourStateListener(object : LeaveCurrentTourDialogFragment.LeaveTourCallback {
                 override fun leftTour() {
                     viewModel.leaveCurrentTour()
                 }
@@ -438,8 +445,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     override fun onResume() {
         super.onResume()
         mapView.onResume()
-        viewModel.onResume(getLatestTourObject(), getStartTourStop(), getLatestSearchObject())
-        viewModel.loadMapDisplayMode(getLatestTourObject(), getStartTourStop())
+        viewModel.onResume(getLatestTourObject(), getStartTourStop(), getLatestSearchObject(), getLatestSearchObjectType())
     }
 
     override fun onPause() {

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -72,7 +72,9 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private var leaveTourDialog: LeaveCurrentTourDialogFragment? = null
 
     private fun getLatestSearchObject(): ArticObject? {
-        return requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
+        val data : ArticObject? = requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
+        requireActivity().intent?.removeExtra(ARG_SEARCH_OBJECT)
+        return data
     }
 
     private fun getLatestSearchObjectType(): String? {
@@ -252,8 +254,17 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { searchObject ->
                     when (searchObject) {
-                        is MapDisplayMode.Search.ObjectSearch -> displayFragmentInInfoContainer(SearchObjectDetailsFragment.loadArtworkResults(searchObject.item), SEARCH_DETILAS)
-                        is MapDisplayMode.Search.AmenitiesSearch -> displayFragmentInInfoContainer(SearchObjectDetailsFragment.loadAmenitiesByType(searchObject.item), SEARCH_DETILAS)
+                        is MapDisplayMode.Search.ObjectSearch -> {
+                            displayFragmentInInfoContainer(
+                                    SearchObjectDetailsFragment.loadArtworkResults(searchObject.item),
+                                    SEARCH_DETAILS
+                            )
+                        }
+                        is MapDisplayMode.Search.AmenitiesSearch ->
+                            displayFragmentInInfoContainer(
+                                    SearchObjectDetailsFragment.loadAmenitiesByType(searchObject.item),
+                                    SEARCH_DETAILS
+                            )
                     }
                 }
                 .disposedBy(disposeBag)
@@ -265,8 +276,8 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy {
                     when (it) {
-                        is MapDisplayMode.Tour -> hideFragmentInInfoContainer(SEARCH_DETILAS)
-                        is MapDisplayMode.CurrentFloor -> hideFragmentInInfoContainer(SEARCH_DETILAS)
+                        is MapDisplayMode.Tour -> hideFragmentInInfoContainer(SEARCH_DETAILS)
+                        is MapDisplayMode.CurrentFloor -> hideFragmentInInfoContainer(SEARCH_DETAILS)
                         is MapDisplayMode.Search<*> -> hideFragmentInInfoContainer(OBJECT_DETAILS)
                     }
                 }
@@ -495,6 +506,6 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
     companion object {
         const val OBJECT_DETAILS = "object-details"
-        const val SEARCH_DETILAS = "SEARCH"
+        const val SEARCH_DETAILS = "SEARCH"
     }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -305,6 +305,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
         viewModel.distinctFloor
                 .withLatestFrom(groundOverlayGenerated)
+                .observeOn(AndroidSchedulers.mainThread())
                 .filter { (floor, generated) -> generated && floor in 0..3 }
                 .withLatestFrom(viewModel.currentMap.filterValue()) { (floor), map -> floor to map }
                 .subscribeBy { (floor, map) ->

--- a/map/src/main/kotlin/edu/artic/map/MapMarkerConstructor.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapMarkerConstructor.kt
@@ -39,7 +39,7 @@ class MapMarkerConstructor
 
     private val landmarkMapItemRenderer = LandmarkMapItemRenderer(articMapAnnotationDao)
     private val spacesMapItemRenderer = SpacesMapItemRenderer(articMapAnnotationDao)
-    val amenitiesMapItemRenderer = AmenitiesMapItemRenderer(articMapAnnotationDao)
+    private val amenitiesMapItemRenderer = AmenitiesMapItemRenderer(articMapAnnotationDao)
     private val departmentsMapItemRenderer = DepartmentsMapItemRenderer(articMapAnnotationDao)
     private val galleriesMapItemRenderer = GalleriesMapItemRenderer(galleryDao)
     private val tourIntroMapItemRenderer = TourIntroMapItemRenderer()

--- a/map/src/main/kotlin/edu/artic/map/MapMarkerConstructor.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapMarkerConstructor.kt
@@ -39,7 +39,7 @@ class MapMarkerConstructor
 
     private val landmarkMapItemRenderer = LandmarkMapItemRenderer(articMapAnnotationDao)
     private val spacesMapItemRenderer = SpacesMapItemRenderer(articMapAnnotationDao)
-    private val amenitiesMapItemRenderer = AmenitiesMapItemRenderer(articMapAnnotationDao)
+    val amenitiesMapItemRenderer = AmenitiesMapItemRenderer(articMapAnnotationDao)
     private val departmentsMapItemRenderer = DepartmentsMapItemRenderer(articMapAnnotationDao)
     private val galleriesMapItemRenderer = GalleriesMapItemRenderer(galleryDao)
     private val tourIntroMapItemRenderer = TourIntroMapItemRenderer()

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -57,6 +57,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         get() = floor.distinctUntilChanged()
 
     val selectedTourStopMarkerId: Subject<String> = BehaviorSubject.create()
+    val selectedDiningPlace: Subject<Optional<ArticMapAnnotation>> = BehaviorSubject.create()
 
     private val visibleRegionChanges: Subject<VisibleRegion> = BehaviorSubject.create()
 
@@ -146,6 +147,24 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                     displayModeChanged(MapDisplayMode.CurrentFloor)
                 }.disposedBy(disposeBag)
 
+        /**
+         * Update map bounds to focus selected annotation.
+         * Used by dining carousel.
+         */
+
+        searchManager.activeDiningPlace
+                .bindToMain(selectedDiningPlace)
+                .disposedBy(disposeBag)
+
+        searchManager.activeDiningPlace
+                .filterValue()
+                .delay(750, TimeUnit.MILLISECONDS)
+                .subscribe { diningPlace ->
+                    diningPlace.floor?.let {
+                        floorChangedTo(it)
+                    }
+                }
+                .disposedBy(disposeBag)
 
         this.currentMap
                 .bindTo(mapMarkerConstructor.map)

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -274,7 +274,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     /**
      * Loads display mode for the map.
      */
-    fun onResume(requestedTour: ArticTour?, requestedTourStop: ArticTour.TourStop?, searchedObject: ArticObject?) {
+    fun onResume(requestedTour: ArticTour?, requestedTourStop: ArticTour.TourStop?, searchedObject: ArticObject?, searchedAnnotationType: String?) {
 
         /**
          * Store the search object to memory.
@@ -287,6 +287,11 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
          */
         searchedObject?.let {
             searchManager.selectedObject.onNext(Optional(searchedObject))
+        }
+
+        searchedAnnotationType?.let {
+            searchManager.selectedObject.onNext(Optional(null))
+            searchManager.selectedAmenityType.onNext(Optional(it))
         }
 
         loadMapDisplayMode(requestedTour, requestedTourStop)

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -165,7 +165,9 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
                 .bindToMain(tourBoundsChanged)
                 .disposedBy(disposeBag)
 
-        articObjectSelected(displayMode.item as ArticObject)
+        if (displayMode.item is ArticObject) {
+            articObjectSelected(displayMode.item)
+        }
     }
 
     private fun animateToTourStopBounds(displayMode: MapDisplayMode.Tour) {

--- a/map/src/main/kotlin/edu/artic/map/SearchManager.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchManager.kt
@@ -25,4 +25,11 @@ class SearchManager {
     val activeDiningPlace: Subject<Optional<ArticMapAnnotation>> = BehaviorSubject.createDefault(Optional(null))
 
     val leaveSearchMode: Subject<Boolean> = PublishSubject.create()
+
+    fun clearSearch() {
+        selectedObject.onNext(Optional(null))
+        selectedAmenityType.onNext(Optional(null))
+        activeDiningPlace.onNext(Optional(null))
+        leaveSearchMode.onNext(true)
+    }
 }

--- a/map/src/main/kotlin/edu/artic/map/SearchManager.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchManager.kt
@@ -1,8 +1,8 @@
 package edu.artic.map
 
 import com.fuzz.rx.Optional
+import edu.artic.db.models.ArticMapAnnotation
 import edu.artic.db.models.ArticObject
-import edu.artic.db.models.ArticTour
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
@@ -20,7 +20,9 @@ class SearchManager {
     /**
      * Save the last selected tour.
      */
-    val selectedAmenityType: Subject<Optional<ArticObject>> = BehaviorSubject.createDefault(Optional(null))
+    val selectedAmenityType: Subject<Optional<String>> = BehaviorSubject.createDefault(Optional(null))
+
+    val activeDiningPlace: Subject<Optional<ArticMapAnnotation>> = BehaviorSubject.createDefault(Optional(null))
 
     val leaveSearchMode: Subject<Boolean> = PublishSubject.create()
 }

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
@@ -71,9 +71,7 @@ class SearchObjectDetailsFragment : BaseViewModelFragment<SearchObjectDetailsVie
                 .observeOn(AndroidSchedulers.mainThread())
                 .withLatestFrom(audioService) { playControl, service ->
                     playControl to service
-                }.subscribe { pair ->
-                    val playControl = pair.first
-                    val service = pair.second
+                }.subscribeBy { (playControl, service) ->
                     when (playControl) {
                         is SearchObjectBaseViewModel.PlayerAction.Play -> {
                             if (playControl.audioFileModel != null) {

--- a/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
@@ -1,0 +1,137 @@
+package edu.artic.map
+
+import android.view.View
+import com.bumptech.glide.Glide
+import com.fuzz.rx.bindToMain
+import com.fuzz.rx.defaultThrottle
+import com.fuzz.rx.disposedBy
+import com.jakewharton.rxbinding2.view.clicks
+import com.jakewharton.rxbinding2.view.visibility
+import com.jakewharton.rxbinding2.widget.text
+import edu.artic.adapter.AutoHolderRecyclerViewAdapter
+import edu.artic.adapter.BaseViewHolder
+import edu.artic.media.audio.AudioPlayerService
+import io.reactivex.android.schedulers.AndroidSchedulers
+import kotlinx.android.synthetic.main.layout_amenity_search_cell.view.*
+import kotlinx.android.synthetic.main.layout_artwork_search_cell.view.*
+
+/**
+@author Sameer Dhakal (Fuzz)
+ */
+class SearchedObjectsAdapter : AutoHolderRecyclerViewAdapter<SearchObjectBaseViewModel>() {
+
+    override fun View.onBindView(item: SearchObjectBaseViewModel, position: Int) {
+        when (item) {
+            is DiningAnnotationViewModel -> {
+
+                item.imageUrl
+                        .map { it.isNotEmpty() }
+                        .bindToMain(amenityImage.visibility())
+                        .disposedBy(item.viewDisposeBag)
+
+                item.imageUrl
+                        .filter { it.isNotEmpty() }
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe {
+                            Glide.with(this)
+                                    .load(it)
+                                    .into(amenityImage)
+                        }
+                        .disposedBy(item.viewDisposeBag)
+
+                item.title
+                        .bindToMain(amenityType.text())
+                        .disposedBy(item.viewDisposeBag)
+
+                item.description
+                        .bindToMain(amenityDetails.text())
+                        .disposedBy(item.viewDisposeBag)
+
+            }
+            is AnnotationViewModel -> {
+                item.title
+                        .bindToMain(amenityType.text())
+                        .disposedBy(item.viewDisposeBag)
+
+                item.description
+                        .bindToMain(amenityDetails.text())
+                        .disposedBy(item.viewDisposeBag)
+            }
+            is ArtworkViewModel -> {
+
+                item.imageUrl
+                        .filter { it.isNotEmpty() }
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe {
+                            Glide.with(this)
+                                    .load(it)
+                                    .into(objectImage)
+                        }
+                        .disposedBy(item.viewDisposeBag)
+
+                item.artworkTitle
+                        .bindToMain(objectTitle.text())
+                        .disposedBy(item.viewDisposeBag)
+
+                item.artistName
+                        .bindToMain(artist.text())
+                        .disposedBy(item.viewDisposeBag)
+
+                item.objectType
+                        .bindToMain(objectType.text())
+                        .disposedBy(item.viewDisposeBag)
+
+                playCurrent.clicks()
+                        .defaultThrottle()
+                        .subscribe {
+                            item.playAudioTranslation()
+                        }.disposedBy(item.viewDisposeBag)
+
+                pauseCurrent.clicks()
+                        .defaultThrottle()
+                        .subscribe {
+                            item.pauseAudioTranslation()
+                        }.disposedBy(item.viewDisposeBag)
+
+                item.playState.subscribe {playBackState->
+                    when (playBackState) {
+                        is AudioPlayerService.PlayBackState.Playing -> {
+                            playCurrent.visibility = View.INVISIBLE
+                            pauseCurrent.visibility = View.VISIBLE
+                        }
+                        is AudioPlayerService.PlayBackState.Paused -> {
+                            playCurrent.visibility = View.VISIBLE
+                            pauseCurrent.visibility = View.INVISIBLE
+                        }
+                        is AudioPlayerService.PlayBackState.Stopped -> {
+                            playCurrent.visibility = View.VISIBLE
+                            pauseCurrent.visibility = View.INVISIBLE
+                        }
+                    }
+                }.disposedBy(item.viewDisposeBag)
+
+            }
+        }
+    }
+
+    override fun getLayoutResId(position: Int): Int {
+        val item = getItem(position)
+        return when (item) {
+            is DiningAnnotationViewModel -> R.layout.layout_amenity_search_cell
+            is AnnotationViewModel -> R.layout.layout_amenity_search_cell
+            is ArtworkViewModel -> R.layout.layout_artwork_search_cell
+            else -> {
+                0
+                /* should never reach here*/
+            }
+        }
+    }
+
+    override fun onItemViewDetachedFromWindow(holder: BaseViewHolder, position: Int) {
+        super.onItemViewDetachedFromWindow(holder, position)
+        getItem(position).apply {
+            cleanup()
+            onCleared()
+        }
+    }
+}

--- a/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
@@ -129,8 +129,7 @@ class SearchedObjectsAdapter : AutoHolderRecyclerViewAdapter<SearchObjectBaseVie
 
     override fun onItemViewDetachedFromWindow(holder: BaseViewHolder, position: Int) {
         super.onItemViewDetachedFromWindow(holder, position)
-        getItem(position).apply {
-            cleanup()
+        getItemOrNull(position)?.apply {
             onCleared()
         }
     }

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselViewModel.kt
@@ -211,6 +211,7 @@ class TourCarousalStopCellViewModel(tourStop: ArticTour.TourStop, objectDao: Art
                 .filter { it.galleryLocation != null }
                 .map { it.galleryLocation!! }
                 .bindTo(galleryText)
+                .disposedBy(disposeBag)
 
         /**
          * Display play icon if the current stop's audio is already playing

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
@@ -123,6 +123,15 @@ class AmenitiesMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao) : M
         }
     }
 
+    override fun getMarkerAlpha(floor: Int, mapDisplayMode: MapDisplayMode, item: ArticMapAnnotation): Float {
+        return if (mapDisplayMode is MapDisplayMode.Search.AmenitiesSearch) {
+            if (item.floor == floor) ALPHA_VISIBLE else ALPHA_DIMMED
+        } else {
+            ALPHA_VISIBLE
+        }
+    }
+
+
     override fun getVisibleMapFocus(displayMode: MapDisplayMode): Set<MapFocus> = MapFocus.values().toSet() // all zoom levels
 
     override fun getFastBitmap(item: ArticMapAnnotation, displayMode: MapDisplayMode): BitmapDescriptor {

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
@@ -101,11 +101,25 @@ class SpacesMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao)
 
 class AmenitiesMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao) : MapAnnotationItemRenderer(articMapAnnotationDao) {
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticMapAnnotation>> {
-        return when(displayMode) {
-            is MapDisplayMode.Search<*> ->
+        return when (displayMode) {
+            is MapDisplayMode.Search.ObjectSearch ->
                 listOf<ArticMapAnnotation>().asFlowable()
-            else ->
-                articMapAnnotationDao.getAmenitiesOnMapForFloor(floor = floor.toString())
+            is MapDisplayMode.Search.AmenitiesSearch -> {
+                val amenityType = ArticMapAmenityType.getAmenityTypes(displayMode.item)
+                if (displayMode.item == ArticMapAmenityType.DINING) {
+                    articMapAnnotationDao.getAmenitiesByAmenityType(amenityType = amenityType)
+                } else {
+                    articMapAnnotationDao.getAmenitiesByAmenityType(floor = floor.toString(), amenityType = amenityType)
+                }
+            }
+            is MapDisplayMode.Tour ->{
+                /**
+                 * Only display restrooms on tour mode.
+                 */
+                val amenityTypes = ArticMapAmenityType.getAmenityTypes(ArticMapAmenityType.RESTROOMS)
+                articMapAnnotationDao.getAmenitiesByAmenityType(floor = floor.toString(), amenityType = amenityTypes)
+            }
+            else -> articMapAnnotationDao.getAmenitiesOnMapForFloor(floor = floor.toString())
         }
     }
 

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
@@ -10,21 +10,15 @@ import com.google.android.gms.maps.model.LatLng
 import edu.artic.db.daos.ArticGalleryDao
 import edu.artic.db.daos.ArticMapAnnotationDao
 import edu.artic.db.models.ArticGallery
+import edu.artic.db.models.ArticMapAmenityType
 import edu.artic.db.models.ArticMapAnnotation
 import edu.artic.db.models.ArticMapTextType
 import edu.artic.image.asRequestObservable
 import edu.artic.image.toBitmap
-import edu.artic.map.DepartmentMarkerGenerator
-import edu.artic.map.MapDisplayMode
-import edu.artic.map.MapFocus
-import edu.artic.map.R
-import edu.artic.map.TextMarkerGenerator
-import edu.artic.map.amenityIconForAmenityType
+import edu.artic.map.*
 import edu.artic.map.helpers.toLatLng
-import edu.artic.ui.util.asCDNUri
 import io.reactivex.Flowable
 import io.reactivex.Observable
-import io.reactivex.rxkotlin.toFlowable
 
 internal const val ALPHA_DIMMED = 0.6f
 internal const val ALPHA_VISIBLE = 1.0f
@@ -65,7 +59,7 @@ class LandmarkMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao) : Ma
     private val textMarkerGenerator: TextMarkerGenerator by lazy { TextMarkerGenerator(context) }
 
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticMapAnnotation>> {
-        return when(displayMode) {
+        return when (displayMode) {
             is MapDisplayMode.Search<*> ->
                 listOf<ArticMapAnnotation>().asFlowable()
             else ->
@@ -88,7 +82,7 @@ class SpacesMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao)
     private val textMarkerGenerator: TextMarkerGenerator  by lazy { TextMarkerGenerator(context) }
 
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticMapAnnotation>> {
-        return when(displayMode) {
+        return when (displayMode) {
             is MapDisplayMode.Search<*> ->
                 listOf<ArticMapAnnotation>().asFlowable()
             else ->
@@ -130,7 +124,7 @@ class DepartmentsMapItemRenderer(articMapAnnotationDao: ArticMapAnnotationDao)
     private val departmentMarkerGenerator: DepartmentMarkerGenerator by lazy { DepartmentMarkerGenerator(context) }
 
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticMapAnnotation>> {
-        return when(displayMode) {
+        return when (displayMode) {
             is MapDisplayMode.Search<*> ->
                 listOf<ArticMapAnnotation>().asFlowable()
             else ->
@@ -158,7 +152,7 @@ class GalleriesMapItemRenderer(private val galleriesDao: ArticGalleryDao)
     private val textMarkerGenerator: TextMarkerGenerator by lazy { TextMarkerGenerator(context) }
 
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticGallery>> {
-        return when(displayMode) {
+        return when (displayMode) {
             is MapDisplayMode.Search<*> ->
                 listOf<ArticGallery>().asFlowable()
             else ->

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -27,6 +27,7 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.rxkotlin.toFlowable
 import io.reactivex.rxkotlin.withLatestFrom
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
@@ -139,7 +140,8 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticObject>> = when (displayMode) {
         is MapDisplayMode.CurrentFloor -> objectsDao.getObjectsByFloor(floor = floor)
         is MapDisplayMode.Tour -> objectsDao.getObjectsByIdList(displayMode.tour.tourStops.mapNotNull { it.objectId })
-        is MapDisplayMode.Search<*> -> objectsDao.getObjectById((displayMode.item as ArticObject).nid).map { listOf(it) }
+        is MapDisplayMode.Search.ObjectSearch -> objectsDao.getObjectById(displayMode.item.nid).map { listOf(it) }
+        is MapDisplayMode.Search.AmenitiesSearch -> listOf<List<ArticObject>>().toFlowable()
     }
 
     override fun getVisibleMapFocus(displayMode: MapDisplayMode): Set<MapFocus> =
@@ -180,7 +182,7 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
 
     override fun getMarkerAlpha(floor: Int, mapDisplayMode: MapDisplayMode, item: ArticObject): Float {
         // on tour, set the alpha depending on current floor.
-        return if (mapDisplayMode is MapDisplayMode.Tour) {
+        return if (mapDisplayMode is MapDisplayMode.Tour || mapDisplayMode is MapDisplayMode.Search.ObjectSearch) {
             if (item.floor == floor) ALPHA_VISIBLE else ALPHA_DIMMED
         } else {
             ALPHA_VISIBLE

--- a/map/src/main/res/layout/fragment_search_object_details.xml
+++ b/map/src/main/res/layout/fragment_search_object_details.xml
@@ -5,9 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
     android:background="@color/mapObjectWindowBlue"
     android:clickable="true"
-    android:layout_gravity="bottom"
     android:focusable="true">
 
     <android.support.constraint.ConstraintLayout
@@ -26,6 +26,7 @@
             android:paddingTop="@dimen/marginDouble"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:background="#fab" />
 
         <com.fuzz.indicator.CutoutViewIndicator
@@ -49,11 +50,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:padding="@dimen/marginStandard"
         android:layout_marginTop="@dimen/marginDouble"
         android:layout_marginEnd="@dimen/marginDouble"
         android:layout_marginBottom="@dimen/marginDouble"
         android:contentDescription="@null"
+        android:padding="@dimen/marginStandard"
         android:src="@drawable/ic_close_black_24dp" />
 
 </FrameLayout>

--- a/map/src/main/res/layout/fragment_search_object_details.xml
+++ b/map/src/main/res/layout/fragment_search_object_details.xml
@@ -1,133 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/mapObjectWindowBlue"
     android:clickable="true"
+    android:layout_gravity="bottom"
     android:focusable="true">
 
-    <TextView
-        android:id="@+id/searchType"
-        style="@style/SectionTitleWhite"
-        android:layout_width="0dp"
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/marginDouble"
-        android:ellipsize="end"
-        android:gravity="start"
-        android:lines="1"
-        android:text="Artworks"
-        app:layout_constraintEnd_toStartOf="@id/close"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        android:layout_gravity="bottom"
+        android:background="@null"
+        android:clickable="true"
+        android:focusable="true">
+
+        <android.support.v4.view.ViewPager
+            android:id="@+id/searchResults"
+            android:layout_width="0dp"
+            android:layout_height="206dp"
+            android:layout_marginBottom="@dimen/marginSixtyFour"
+            android:paddingTop="@dimen/marginDouble"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:background="#fab" />
+
+        <com.fuzz.indicator.CutoutViewIndicator
+            android:id="@+id/viewPagerIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:layout_alignParentBottom="true"
+            android:layout_centerInParent="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/searchResults"
+            app:rcv_drawable="@drawable/icn_indicator_selected"
+            app:rcv_drawable_unselected="@drawable/icn_indicator"
+            app:rcv_internal_margin="8dp"
+            app:rcv_tools_indicator_count="2" />
+
+    </android.support.constraint.ConstraintLayout>
 
     <ImageView
         android:id="@+id/close"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:padding="@dimen/marginStandard"
         android:layout_marginTop="@dimen/marginDouble"
         android:layout_marginEnd="@dimen/marginDouble"
         android:layout_marginBottom="@dimen/marginDouble"
         android:contentDescription="@null"
-        android:src="@drawable/ic_close_black_24dp"
-        app:layout_constraintBottom_toBottomOf="@+id/searchType"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/searchType"
-        app:layout_constraintTop_toTopOf="@+id/searchType" />
+        android:src="@drawable/ic_close_black_24dp" />
 
-    <View
-        android:id="@+id/divider"
-        style="@style/divider"
-        android:layout_width="0dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginTop="@dimen/marginDouble"
-        android:layout_marginEnd="0dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchType" />
-
-    <ImageView
-        android:id="@+id/image"
-        android:layout_width="72dp"
-        android:layout_height="45dp"
-        android:layout_marginStart="@dimen/marginDouble"
-        android:layout_marginTop="@dimen/marginDouble"
-        android:layout_marginBottom="@dimen/marginSixtyFour"
-        android:contentDescription="@null"
-        android:scaleType="matrix"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider"
-        tools:background="@color/brownishOrange" />
-
-    <TextView
-        android:id="@+id/searchObjectTitle"
-        style="@style/ListItemTitle1White"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginDouble"
-        android:layout_marginTop="@dimen/marginDouble"
-        android:layout_marginEnd="@dimen/marginStandard"
-        android:ellipsize="end"
-        android:gravity="start"
-        android:lines="1"
-        app:layout_constraintEnd_toStartOf="@id/barrier"
-        app:layout_constraintStart_toEndOf="@id/image"
-        app:layout_constraintTop_toTopOf="@+id/divider"
-        tools:text="Introduction IntroductionIntroductionIntroductionIntroductionIntroduction" />
-
-    <TextView
-        android:id="@+id/subtitle"
-        style="@style/ListItemTitle2White"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginDouble"
-        android:layout_marginEnd="@dimen/marginStandard"
-        android:gravity="start"
-        android:lines="1"
-        app:layout_constraintEnd_toStartOf="@id/barrier"
-        app:layout_constraintStart_toEndOf="@id/image"
-        app:layout_constraintTop_toBottomOf="@+id/searchObjectTitle"
-        tools:text="Gallery 201" />
-
-
-    <ImageButton
-        android:id="@+id/playCurrent"
-        android:layout_width="@dimen/bottomAudioControlIconSize"
-        android:layout_height="@dimen/bottomAudioControlIconSize"
-        android:layout_marginEnd="@dimen/marginDouble"
-        android:background="@drawable/ic_play"
-        android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="@id/image"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/image" />
-
-    <ImageButton
-        android:id="@+id/pauseCurrent"
-        android:layout_width="@dimen/bottomAudioControlIconSize"
-        android:layout_height="@dimen/bottomAudioControlIconSize"
-        android:layout_marginEnd="@dimen/marginDouble"
-        android:background="@drawable/ic_pause"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/image"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/image" />
-
-    <android.support.constraint.Barrier
-        android:id="@+id/barrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="start"
-        app:constraint_referenced_ids="playCurrent,pauseCurrent"
-        tools:ignore="MissingConstraints" />
-
-    <Space
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/marginSixtyFour"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/viewPagerIndicator" />
-
-</android.support.constraint.ConstraintLayout>
+</FrameLayout>

--- a/map/src/main/res/layout/layout_amenity_search_cell.xml
+++ b/map/src/main/res/layout/layout_amenity_search_cell.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/mapObjectWindowBlue"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/amenityType"
+        style="@style/SectionTitleWhite"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginTriple"
+        android:layout_marginTop="@dimen/marginStandard"
+        android:layout_marginEnd="@dimen/marginTriple"
+        android:ellipsize="end"
+        android:fontFamily="@font/ideal_sans_book"
+        android:lines="1"
+        android:textAlignment="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="ArtworksArtworksArtworksArtworksArtworksArtworksArtworks" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/divider"
+        android:layout_width="0dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="@dimen/marginStandard"
+        android:layout_marginEnd="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/amenityType" />
+
+    <ImageView
+        android:id="@+id/amenityImage"
+        android:layout_width="72dp"
+        android:layout_height="45dp"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginBottom="@dimen/marginSixtyFour"
+        android:contentDescription="@null"
+        android:scaleType="matrix"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:layout_constraintVertical_bias="0"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
+        tools:background="@color/brownishOrange" />
+
+    <TextView
+        android:id="@+id/amenityDetails"
+        style="@style/ListItemTitle2White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginEnd="@dimen/marginStandard"
+        android:layout_marginBottom="@dimen/marginSixtyFour"
+        android:fontFamily="@font/ideal_sans_medium"
+        android:gravity="start"
+        android:lineSpacingMultiplier="0.7"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/amenityImage"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
+        app:layout_constraintVertical_bias="0"
+        tools:text="Monday Tuesday" />
+
+</android.support.constraint.ConstraintLayout>

--- a/map/src/main/res/layout/layout_artwork_search_cell.xml
+++ b/map/src/main/res/layout/layout_artwork_search_cell.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/mapObjectWindowBlue"
+    android:layout_gravity="bottom"
+    android:clickable="true"
+    tools:layout_height="match_parent"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/objectType"
+        style="@style/SectionTitleWhite"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/marginStandard"
+        android:ellipsize="end"
+        android:gravity="start"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@id/barrier"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Artworks" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/divider"
+        android:layout_width="0dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="@dimen/marginStandard"
+        android:layout_marginEnd="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/objectType" />
+
+    <ImageView
+        android:id="@+id/objectImage"
+        android:layout_width="72dp"
+        android:layout_height="45dp"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginBottom="@dimen/marginSixtyFour"
+        android:contentDescription="@null"
+        android:scaleType="matrix"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
+        app:layout_constraintVertical_bias="0"
+        tools:background="@color/brownishOrange" />
+
+    <TextView
+        android:id="@+id/objectTitle"
+        style="@style/ListItemTitle1White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginEnd="@dimen/marginStandard"
+        android:ellipsize="end"
+        android:gravity="start"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@id/barrier"
+        app:layout_constraintStart_toEndOf="@id/objectImage"
+        app:layout_constraintTop_toTopOf="@+id/divider"
+        tools:text="Mona Lisa" />
+
+    <TextView
+        android:id="@+id/artist"
+        style="@style/ListItemTitle2White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginEnd="@dimen/marginStandard"
+        android:gravity="start"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@id/barrier"
+        app:layout_constraintStart_toEndOf="@id/objectImage"
+        app:layout_constraintTop_toBottomOf="@+id/objectTitle"
+        tools:text="Leonardo da vinci" />
+
+
+    <ImageButton
+        android:id="@+id/playCurrent"
+        android:layout_width="@dimen/bottomAudioControlIconSize"
+        android:layout_height="@dimen/bottomAudioControlIconSize"
+        android:layout_marginEnd="@dimen/marginDouble"
+        android:background="@drawable/ic_play"
+        android:visibility="visible"
+        app:layout_constraintVertical_bias="0"
+        app:layout_constraintBottom_toBottomOf="@id/objectImage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/objectImage" />
+
+    <ImageButton
+        android:id="@+id/pauseCurrent"
+        android:layout_width="@dimen/bottomAudioControlIconSize"
+        android:layout_height="@dimen/bottomAudioControlIconSize"
+        android:layout_marginEnd="@dimen/marginDouble"
+        android:background="@drawable/ic_pause"
+        app:layout_constraintVertical_bias="0"
+        tools:visibility="gone"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/objectImage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/objectImage" />
+
+    <android.support.constraint.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="start"
+        app:constraint_referenced_ids="playCurrent,pauseCurrent"
+        tools:ignore="MissingConstraints" />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/marginSixtyFour"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/viewPagerIndicator" />
+
+</android.support.constraint.ConstraintLayout>

--- a/navigation/src/main/java/edu/artic/navigation/NavigationConstants.kt
+++ b/navigation/src/main/java/edu/artic/navigation/NavigationConstants.kt
@@ -14,5 +14,6 @@ class NavigationConstants {
         const val ARG_SEARCH_OBJECT: String = "ARG_SEARCH_OBJECT"
         const val ARG_TOUR = "ARG_TOUR"
         const val ARG_TOUR_START_STOP = "ARG_TOUR_START_STOP"
+        const val ARG_AMENITY_TYPE: String = "ARG_AMENITY_TYPE"
     }
 }

--- a/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsFragment.kt
+++ b/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsFragment.kt
@@ -6,6 +6,10 @@ import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.analytics.ScreenCategoryName
+import edu.artic.base.utils.asDeepLinkIntent
+import edu.artic.navigation.NavigationConstants
+import edu.artic.navigation.NavigationConstants.Companion.ARG_SEARCH_OBJECT
+import edu.artic.viewmodel.Navigate
 import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.fragment_search_results_sub.*
 import kotlin.reflect.KClass

--- a/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsViewModel.kt
@@ -25,10 +25,10 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
 
     private fun getAmenitiesViewModels(): List<SearchBaseCellViewModel> {
         return listOf(
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenites.Dining),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenites.MembersLounge),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenites.GiftShop),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenites.Restrooms))
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms))
     }
 
     init {

--- a/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/artic/edu/search/DefaultSearchSuggestionsViewModel.kt
@@ -5,8 +5,6 @@ import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.daos.ArticSearchObjectDao
-import edu.artic.db.models.ArticObject
-import edu.artic.viewmodel.Navigate
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
@@ -27,10 +25,10 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
 
     private fun getAmenitiesViewModels(): List<SearchBaseCellViewModel> {
         return listOf(
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom))
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenites.Dining),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenites.MembersLounge),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenites.GiftShop),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenites.Restrooms))
     }
 
     init {

--- a/search/src/main/java/artic/edu/search/SearchAudioDetailFragment.kt
+++ b/search/src/main/java/artic/edu/search/SearchAudioDetailFragment.kt
@@ -1,5 +1,6 @@
 package artic.edu.search
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import com.bumptech.glide.Glide
@@ -10,10 +11,13 @@ import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.analytics.ScreenCategoryName
+import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.updateDetailTitle
 import edu.artic.db.models.ArticObject
 import edu.artic.image.listenerAnimateSharedTransaction
+import edu.artic.navigation.NavigationConstants
 import edu.artic.viewmodel.BaseViewModelFragment
+import edu.artic.viewmodel.Navigate
 import kotlinx.android.synthetic.main.fragment_search_audio_detail.*
 import kotlin.reflect.KClass
 
@@ -90,6 +94,21 @@ class SearchAudioDetailFragment : BaseViewModelFragment<SearchAudioDetailViewMod
 
     override fun setupNavigationBindings(viewModel: SearchAudioDetailViewModel) {
         super.setupNavigationBindings(viewModel)
+        viewModel.navigateTo
+                .filter { it is Navigate.Forward }
+                .map { it as Navigate.Forward }
+                .subscribe {
+                    when (it.endpoint) {
+                        is SearchAudioDetailViewModel.NavigationEndpoint.ObjectOnMap -> {
+                            val o = (it.endpoint as SearchAudioDetailViewModel.NavigationEndpoint.ObjectOnMap).articObject
+                            val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
+                                putExtra(NavigationConstants.ARG_SEARCH_OBJECT, o)
+                                flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
+                            }
+                            startActivity(mapIntent)
+                        }
+                    }
+                }.disposedBy(navigationDisposeBag)
     }
 
 

--- a/search/src/main/java/artic/edu/search/SearchAudioDetailViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchAudioDetailViewModel.kt
@@ -3,11 +3,12 @@ package artic.edu.search
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import com.fuzz.rx.filterFlatMap
+import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
-import edu.artic.base.utils.DateTimeHelper
-import edu.artic.db.models.ArticEvent
+import edu.artic.analytics.ScreenCategoryName
 import edu.artic.db.models.ArticObject
 import edu.artic.viewmodel.NavViewViewModel
+import edu.artic.viewmodel.Navigate
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import javax.inject.Inject
@@ -15,7 +16,9 @@ import javax.inject.Inject
 class SearchAudioDetailViewModel @Inject constructor(private val analyticsTracker: AnalyticsTracker)
     : NavViewViewModel<SearchAudioDetailViewModel.NavigationEndpoint>() {
 
-    sealed class NavigationEndpoint
+    sealed class NavigationEndpoint{
+        data class ObjectOnMap(val articObject: ArticObject) : NavigationEndpoint()
+    }
 
     val imageUrl: Subject<String> = BehaviorSubject.create()
     val title: Subject<String> = BehaviorSubject.createDefault("test")
@@ -53,7 +56,14 @@ class SearchAudioDetailViewModel @Inject constructor(private val analyticsTracke
     }
 
     fun onClickShowOnMap() {
-        //TODO: go to map to show this
+        articObject?.let{ articObj->
+            analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowArtwork, articObj.title)
+            navigateTo.onNext(
+                    Navigate.Forward(
+                            NavigationEndpoint.ObjectOnMap(articObj)
+                    )
+            )
+        }
     }
 
     fun onClickPlayAudio() {

--- a/search/src/main/java/artic/edu/search/SearchBaseFragment.kt
+++ b/search/src/main/java/artic/edu/search/SearchBaseFragment.kt
@@ -13,6 +13,7 @@ import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.exhibitions.ExhibitionDetailFragment
 import edu.artic.navigation.NavigationConstants
+import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
 import edu.artic.tours.TourDetailsFragment
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
@@ -96,8 +97,13 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
                                     SearchAudioDetailFragment.argsBundle(o)
                             )
                         }
-                        SearchBaseViewModel.NavigationEndpoint.AmenityOnMap -> {
-
+                        is SearchBaseViewModel.NavigationEndpoint.AmenityOnMap -> {
+                            val amenity = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.AmenityOnMap).type
+                            val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
+                                putExtra(ARG_AMENITY_TYPE, amenity.type)
+                                flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
+                            }
+                            startActivity(mapIntent)
                         }
                         SearchBaseViewModel.NavigationEndpoint.Web -> {
 

--- a/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
@@ -23,7 +23,7 @@ open class SearchBaseViewModel @Inject constructor(
         data class ExhibitionDetails(val exhibition: ArticExhibition) : NavigationEndpoint()
         data class ArtworkDetails(val articObject: ArticObject) : NavigationEndpoint()
         data class ArtworkOnMap(val articObject: ArticObject) : NavigationEndpoint()
-        data class AmenityOnMap(val type: SuggestedMapAmenites) : NavigationEndpoint()
+        data class AmenityOnMap(val type: SuggestedMapAmenities) : NavigationEndpoint()
         object Web : NavigationEndpoint()
 
     }

--- a/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
@@ -23,7 +23,7 @@ open class SearchBaseViewModel @Inject constructor(
         data class ExhibitionDetails(val exhibition: ArticExhibition) : NavigationEndpoint()
         data class ArtworkDetails(val articObject: ArticObject) : NavigationEndpoint()
         data class ArtworkOnMap(val articObject: ArticObject) : NavigationEndpoint()
-        object AmenityOnMap : NavigationEndpoint() // TODO: somehting with this?
+        data class AmenityOnMap(val type: SuggestedMapAmenites) : NavigationEndpoint()
         object Web : NavigationEndpoint()
 
     }
@@ -71,7 +71,7 @@ open class SearchBaseViewModel @Inject constructor(
             is SearchAmenitiesCellViewModel -> {
                 navigateTo.onNext(
                         Navigate.Forward(
-                                NavigationEndpoint.AmenityOnMap
+                                NavigationEndpoint.AmenityOnMap(viewModel.type)
                         )
                 )
             }

--- a/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchBaseViewModel.kt
@@ -69,6 +69,20 @@ open class SearchBaseViewModel @Inject constructor(
                 )
             }
             is SearchAmenitiesCellViewModel -> {
+                when (viewModel.type) {
+                    SuggestedMapAmenities.Dining -> {
+                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowDining)
+                    }
+                    SuggestedMapAmenities.Restrooms -> {
+                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowRestrooms)
+                    }
+                    SuggestedMapAmenities.GiftShop -> {
+                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowGiftShops)
+                    }
+                    SuggestedMapAmenities.MembersLounge -> {
+                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowMemberLounge)
+                    }
+                }
                 navigateTo.onNext(
                         Navigate.Forward(
                                 NavigationEndpoint.AmenityOnMap(viewModel.type)

--- a/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
@@ -70,7 +70,7 @@ class SearchCircularCellViewModel(val artWork: ArticObject?) : SearchBaseCellVie
 /**
  * ViewModel for displaying the amenities icons
  */
-class SearchAmenitiesCellViewModel(@DrawableRes val value: Int, val type: SuggestedMapAmenites) : SearchBaseCellViewModel()
+class SearchAmenitiesCellViewModel(@DrawableRes val value: Int, val type: SuggestedMapAmenities) : SearchBaseCellViewModel()
 
 
 

--- a/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
@@ -70,7 +70,7 @@ class SearchCircularCellViewModel(val artWork: ArticObject?) : SearchBaseCellVie
 /**
  * ViewModel for displaying the amenities icons
  */
-class SearchAmenitiesCellViewModel(@DrawableRes val value: Int) : SearchBaseCellViewModel()
+class SearchAmenitiesCellViewModel(@DrawableRes val value: Int, val type: SuggestedMapAmenites) : SearchBaseCellViewModel()
 
 
 

--- a/search/src/main/java/artic/edu/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchSuggestedViewModel.kt
@@ -34,11 +34,11 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
                 .combineLatest(
                         dynamicCells,
                         Observable.just(listOf(
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom),
-                                SearchAmenitiesCellViewModel(0))
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenites.Dining),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenites.MembersLounge),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenites.GiftShop),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenites.Restrooms),
+                                SearchAmenitiesCellViewModel(0,SuggestedMapAmenites.Restrooms))
                         ),
                         suggestedArtworks)
                 { dynamicCells, amenities, suggestedArtworks ->

--- a/search/src/main/java/artic/edu/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/artic/edu/search/SearchSuggestedViewModel.kt
@@ -34,11 +34,14 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
                 .combineLatest(
                         dynamicCells,
                         Observable.just(listOf(
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenites.Dining),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenites.MembersLounge),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenites.GiftShop),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenites.Restrooms),
-                                SearchAmenitiesCellViewModel(0,SuggestedMapAmenites.Restrooms))
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms),
+                                /**
+                                 * TODO:: Refactor it, used something other than SearchAmenitiesCellViewModel (maybe PaddingAmenitiesCellViewModel)
+                                 * **/
+                                SearchAmenitiesCellViewModel(0,SuggestedMapAmenities.Restrooms))
                         ),
                         suggestedArtworks)
                 { dynamicCells, amenities, suggestedArtworks ->

--- a/search/src/main/java/artic/edu/search/SuggestedMapAmenity.kt
+++ b/search/src/main/java/artic/edu/search/SuggestedMapAmenity.kt
@@ -1,0 +1,14 @@
+package artic.edu.search
+
+import edu.artic.db.models.ArticMapAmenityType
+
+/**
+ * @author Sameer Dhakal (Fuzz)
+ */
+
+sealed class SuggestedMapAmenities(val type: String) {
+    object Restrooms : SuggestedMapAmenities(ArticMapAmenityType.RESTROOMS)
+    object GiftShop : SuggestedMapAmenities(ArticMapAmenityType.GIFT_SHOP)
+    object MembersLounge : SuggestedMapAmenities(ArticMapAmenityType.MEMBERS_LOUNGE)
+    object Dining : SuggestedMapAmenities(ArticMapAmenityType.DINING)
+}


### PR DESCRIPTION
Updates
* refactors the search object details screen to dispaly different UI depending to search type
       - for artwork search, search object details displays artwork details
       - for amenity search, it displays amenities of searched type  in map
       - for dining amenity search, it displays carousel with dining hours info

* makes searched object pin translucent if it's not in the active floor