### PR TITLE
App Data Verification (AIC-380)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -135,10 +135,6 @@ class AppDataManager @Inject constructor(
                     }
                 }.flatMap { appDataState ->
                     if (appDataState is ProgressDataState.Done<*>) {
-                        //Save last downloaded headers
-                        appDataState.headers[HEADER_LAST_MODIFIED]?.let {
-                            appDataPreferencesManager.lastModified = it[0]
-                        }
 
                         // runs the whole operation in a transaction.
                         appDatabase.runInTransaction {
@@ -207,6 +203,14 @@ class AppDataManager @Inject constructor(
                                 val artworkSuggestions = searchObject.searchObjects.map { it -> it.toString() }
                                 searchSuggestionDao.setDataObject(ArticSearchSuggestionsObject(searchKeywordSuggestions, artworkSuggestions))
                             }
+
+
+                            // Now that the transaction has reached its end successfully, we may
+                            // save the last-modified date
+                            appDataState.headers[HEADER_LAST_MODIFIED]?.let {
+                                appDataPreferencesManager.lastModified = it[0]
+                            }
+
                         }
 
                     }

--- a/db/src/main/kotlin/edu/artic/db/daos/ArticDataObjectDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticDataObjectDao.kt
@@ -4,6 +4,7 @@ import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
+import android.support.annotation.WorkerThread
 import edu.artic.db.models.ArticDataObject
 import io.reactivex.Flowable
 
@@ -14,4 +15,14 @@ interface ArticDataObjectDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun setDataObject(generalInfo: ArticDataObject): Long
+
+    /**
+     * For sanity checks in [edu.artic.db.AppDataManager.enforceSanityCheck].
+     *
+     * Must return 0 if there's no data, 1 if there _is_ data,
+     * any other number means something is wrong.
+     */
+    @WorkerThread
+    @Query("select count(*) from ArticDataObject where id = 0")
+    fun getRowCount(): Int
 }

--- a/db/src/main/kotlin/edu/artic/db/daos/GeneralInfoDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/GeneralInfoDao.kt
@@ -14,4 +14,13 @@ interface GeneralInfoDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun setGeneralInfo(generalInfo: ArticGeneralInfo): Long
+
+    /**
+     * For sanity checks in [edu.artic.db.AppDataManager.enforceSanityCheck].
+     *
+     * Must return 0 if there's no data, 1 if there _is_ data,
+     * any other number means something is wrong.
+     */
+    @Query("select count(*) from ArticGeneralInfo limit 1")
+    fun getRowCount(): Int
 }


### PR DESCRIPTION
This covers some work found during stress-testing of #111, after it had been merged in. Essentially, the code as written checked whether the `appData-v2.json` headers have the same timestamp as the one we keep on record in `SharedPreferences`. If they matched, we assumed:

1. the database is not empty
and
2. the database contains all of the content necessary to run the app

These assumptions cause some trouble when switching devices or reinstalling the app (as happens regularly during QA stress-testing). To mitigate them, the attached changes will discard our recorded timestamp if

* the database is empty or
* the database is missing the crucial `GeneralInfo` data or
* the database is missing the crucial `DataObject` data.

It also delays the actual recording of that timestamp until we have confirmed the rest of the app data is saved successfully.