### PR TITLE
Track exhibition location in AppData (AIC-381)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -15,11 +15,7 @@ import edu.artic.db.daos.ArticTourDao
 import edu.artic.db.daos.DashboardDao
 import edu.artic.db.daos.GeneralInfoDao
 import edu.artic.db.daos.*
-import edu.artic.db.models.ArticAppData
-import edu.artic.db.models.ArticEvent
-import edu.artic.db.models.ArticExhibition
-import edu.artic.db.models.ArticExhibitionCMS
-import edu.artic.db.models.ArticSearchSuggestionsObject
+import edu.artic.db.models.*
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
 import javax.inject.Inject
@@ -341,6 +337,23 @@ class AppDataManager @Inject constructor(
                                                 }
                                                 exhibitionsById[exhibitionCMS.id]?.order = exhibitionCMS.sort
                                             }
+
+
+                                            val desiredIds = exhibitionsById.values.mapNotNull { it.gallery_id }
+                                            val galleries : List<ArticGallery> = galleryDao.getGalleriesForIdList(desiredIds)
+
+                                            val galleriesById: Map<String?, ArticGallery> = galleries.associateBy { it.galleryId }
+
+                                            list.forEach { exhibition ->
+                                                if (exhibition.gallery_id != null) {
+                                                    val gallery = galleriesById[exhibition.gallery_id]
+                                                    if (gallery?.location != null) {
+                                                        exhibition.latitude = gallery.latitude
+                                                        exhibition.longitude = gallery.longitude
+                                                    }
+                                                }
+                                            }
+
                                             exhibitionDao.updateExhibitions(list)
                                         }
                             }

--- a/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
@@ -22,7 +22,7 @@ import edu.artic.db.models.*
             ArticMapFloor::class,
             ArticSearchSuggestionsObject::class
         ],
-        version = 2,
+        version = 3,
         exportSchema = false
 )
 @TypeConverters(AppConverters::class)

--- a/db/src/main/kotlin/edu/artic/db/daos/ArticGalleryDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticGalleryDao.kt
@@ -13,6 +13,15 @@ interface ArticGalleryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun addGalleries(galleries: List<ArticGallery>)
 
+    /**
+     * Retrieve all galleries with an id in the given list.
+     *
+     * Even if [requestedIds] has duplicates, the response will only contain
+     * at most one of the found galleries.
+     */
+    @Query("select * from ArticGallery where galleryId in (:requestedIds)")
+    fun getGalleriesForIdList(requestedIds: List<String>): List<ArticGallery>
+
     @Query("select * from ArticGallery where floor = :floor")
     fun getGalleriesForFloor(floor: String): Flowable<List<ArticGallery>>
 

--- a/db/src/main/kotlin/edu/artic/db/models/ArticExhibition.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticExhibition.kt
@@ -20,7 +20,18 @@ data class ArticExhibition(
         @Json(name = "id") @PrimaryKey val id: Int,
         @Json(name = "aic_end_at") val aic_end_at: ZonedDateTime,
         @Json(name = "title") val title: String,
-        var order: Int = -1
+        var order: Int = -1,
+
+        /**
+         * This value is defined by the associated [ArticGallery], associated
+         * by [gallery_id].
+         */
+        var latitude: Double? = null,
+        /**
+         * This value is defined by the associated [ArticGallery], associated
+         * by [gallery_id].
+         */
+        var longitude: Double? = null
 ) : Parcelable {
 
     val startTime: ZonedDateTime

--- a/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticGallery.kt
@@ -14,6 +14,10 @@ data class ArticGallery(
         @Json(name = "status") val status: String?,
         @Json(name = "nid") @PrimaryKey val nid: String,
         @Json(name = "type") val type: String?,
+        /**
+         * If this 'location' field is null, [latitude] and [longitude] should not
+         * be used.
+         */
         @Json(name = "location") val location: String?,
         @Json(name = "latitude") val latitude: Double,
         @Json(name = "longitude") val longitude: Double,
@@ -22,7 +26,7 @@ data class ArticGallery(
          * NB: as established by the iOS codebase, please use [title] instead of this field.
          *
          * In the general sense we expect the two fields to be equivalent and this one may
-         * be removed from the dta model in a future commit.
+         * be removed from the data model in a future commit.
          */
         @Json(name = "title_t") val titleT: String?,
         @Json(name = "gallery_id") val galleryId: String?,

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -6,6 +6,7 @@ import com.bumptech.glide.request.RequestOptions
 import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
+import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.asUrlViewIntent
@@ -19,6 +20,12 @@ import timber.log.Timber
 import kotlin.reflect.KClass
 
 
+/**
+ * This is where we show extra information about a specific [ArticExhibition].
+ *
+ * In the UI, it is more frequently called
+ * # On View
+ */
 class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel>() {
 
     override val screenCategory: ScreenCategoryName
@@ -71,6 +78,11 @@ class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel
 
         viewModel.buyTicketsButtonText
                 .bindToMain(buyTickets.text())
+                .disposedBy(disposeBag)
+
+        viewModel.location
+                .map { (lat, long) -> lat != null && long != null }
+                .bindToMain(showOnMap.visibility())
                 .disposedBy(disposeBag)
 
         showOnMap.clicks()

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -97,16 +97,17 @@ class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel
 
     override fun setupNavigationBindings(viewModel: ExhibitionDetailViewModel) {
         viewModel.navigateTo
-                .subscribe {
-                    when (it) {
+                .subscribe { navEvent ->
+                    when (navEvent) {
                         is Navigate.Forward -> {
-                            when (it.endpoint) {
+                            val endpoint = navEvent.endpoint
+
+                            when (endpoint) {
                                 is ExhibitionDetailViewModel.NavigationEndpoint.ShowOnMap -> {
                                     Timber.d("Show on map")
                                 }
 
                                 is ExhibitionDetailViewModel.NavigationEndpoint.BuyTickets -> {
-                                    val endpoint = it.endpoint as ExhibitionDetailViewModel.NavigationEndpoint.BuyTickets
                                     startActivity(endpoint.url.asUrlViewIntent())
                                 }
                             }

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -103,7 +103,7 @@ class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel
 
                         }
                     }
-                }.disposedBy(disposeBag)
+                }.disposedBy(navigationDisposeBag)
     }
 
     companion object {

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
@@ -31,6 +31,13 @@ constructor(dataObjectDao: ArticDataObjectDao, val analyticsTracker: AnalyticsTr
     val buyTicketsButtonText: Subject<String> = BehaviorSubject.createDefault("Buy Tickets")// TODO: replace when special localizer is done
     val description: Subject<String> = BehaviorSubject.createDefault("")
     val throughDate: Subject<String> = BehaviorSubject.createDefault("")
+    /**
+     * Pair of `latitude` to `longitude`.
+     *
+     * Either latitude or longitude may be null, but this always has a value
+     * if the [exhibition] is non-null.
+     */
+    val location: Subject<Pair<Double?, Double?>> = BehaviorSubject.create()
     private val exhibitionObservable: Subject<ArticExhibition> = BehaviorSubject.create()
 
 
@@ -58,6 +65,11 @@ constructor(dataObjectDao: ArticDataObjectDao, val analyticsTracker: AnalyticsTr
                 .filter { it.legacy_image_mobile_url != null }
                 .map { it.legacy_image_mobile_url!! }
                 .bindTo(imageUrl)
+                .disposedBy(disposeBag)
+
+        exhibitionObservable
+                .map { it.latitude to it.longitude }
+                .bindTo(location)
                 .disposedBy(disposeBag)
 
         exhibitionObservable

--- a/details/src/main/res/layout/fragment_exhibition_details.xml
+++ b/details/src/main/res/layout/fragment_exhibition_details.xml
@@ -27,12 +27,14 @@
             android:layout_height="match_parent"
             android:background="@color/greyText">
 
-            <android.support.constraint.Guideline
-                android:id="@+id/centerGuide"
-                android:layout_width="@dimen/marginDouble"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_percent=".5"/>
+            <!--
+
+            Rules: Both 'showOnMap' and 'buyTickets' should be same width,
+            a little under half the window width. Height should be wrap
+            content. If 'showOnMap' is set to VISIBLE, 'buyTickets' should
+            only change position - not size.
+
+            -->
 
             <Button
                 android:id="@+id/showOnMap"
@@ -42,11 +44,15 @@
                 android:layout_marginEnd="@dimen/marginStandard"
                 android:layout_marginStart="@dimen/marginDouble"
                 android:layout_marginTop="21dp"
-                android:drawableLeft="@drawable/ic_show_on_map"
+                android:drawableStart="@drawable/ic_show_on_map"
                 android:padding="@dimen/marginStandard"
-                app:layout_constraintEnd_toStartOf="@id/centerGuide"
+                android:visibility="gone"
+                app:layout_constraintHorizontal_chainStyle="spread"
+                app:layout_constraintHorizontal_weight=".5"
+                app:layout_constraintEnd_toStartOf="@id/buyTickets"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible"
                 tools:text="Show on Map"/>
 
             <Button
@@ -60,10 +66,32 @@
                 android:drawablePadding="@dimen/marginStandard"
                 android:drawableStart="@drawable/ic_ticket"
                 android:padding="@dimen/marginStandard"
+                app:layout_constraintWidth_percent=".45"
+                app:layout_constraintHorizontal_weight=".5"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/centerGuide"
+                app:layout_constraintStart_toEndOf="@id/showOnMap"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="Buy Tickets"/>
+
+            <!--
+
+            The below Barrier is aligned to 'buyTickets', since we
+            don't expect that to be marked GONE at any of the current
+            uses of this file.
+
+            -->
+
+            <android.support.constraint.Barrier
+                android:id="@+id/buttonPanelGuide"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="showOnMap,buyTickets"
+                app:layout_constraintTop_toBottomOf="@id/buyTickets"
+                />
 
             <TextView
                 android:id="@+id/description"
@@ -75,7 +103,7 @@
                 android:layout_marginTop="19dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/showOnMap"
+                app:layout_constraintTop_toBottomOf="@id/buttonPanelGuide"
                 tools:text="More than 30 works from the museum’s collection present a focused retrospective of this “master of the macabre,” whose work even today retains the power to shock, move and fascinate."/>
 
             <TextView


### PR DESCRIPTION
This adds a new pair of 'latitude' and 'longitude' properties to the `ArticExhibition` model. They are derived from an associated `ArticGallery` (via the `ArticExhibition.gallery_id` field) at parse time.

Note that these values are optional because

1. the exhibition may not be assigned a `gallery id` at retrieval time
2. there may not be a gallery in the museum with that `gallery id`
3. the matching gallery may not have usable location data

If no value is found for the location data, `ExhibitionDetailsFragment` will hide its `showOnMap` view - this can be used for quick visual smoke testing of the property load logic in a live build.