### PR TITLE
Search highlight corrections

### DIFF
--- a/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
@@ -24,21 +24,16 @@ open class SearchBaseCellViewModel(var hasDivider: Boolean = false) : BaseViewMo
  *
  * @param textString the text to show on screen
  * @param highlightedText (optional) a substring that, if present in [textString], should
- * be highlighted with a color or bolded or something along those lines
+ * be highlighted with a color or made bold or something along those lines
  */
-class SearchTextCellViewModel(val textString: String, highlightedText: String = "") : SearchBaseCellViewModel() {
+class SearchTextCellViewModel(
+        val textString: String,
+        highlightedText: String = ""
+) : SearchBaseCellViewModel() {
     val text: Subject<Pair<String,String>> = BehaviorSubject.createDefault(Pair(textString, highlightedText))
-    override fun equals(other: Any?): Boolean {
-        return if(other is SearchTextCellViewModel) {
-            other.textString == textString
-        } else {
-            false
-        }
-    }
 
-    override fun hashCode(): Int {
-        return textString.hashCode()
-    }
+    // Warning: overriding ::equals or ::hashCode may prevent the screen from updating correctly.
+
 }
 
 class SearchEmptyCellViewModel : SearchBaseCellViewModel()

--- a/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/artic/edu/search/SearchResultCellViewModels.kt
@@ -10,8 +10,22 @@ import edu.artic.viewmodel.BaseViewModel
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 
+/**
+ * Base class for all of the [BaseViewModel]s in this file.
+ *
+ * Each of these corresponds more-or-less directly to a single
+ * [android.support.v7.widget.RecyclerView.ViewHolder] in the list
+ * of search results.
+ */
 open class SearchBaseCellViewModel(var hasDivider: Boolean = false) : BaseViewModel()
 
+/**
+ * Dedicated subclass for plain-text content, like autocomplete suggestions.
+ *
+ * @param textString the text to show on screen
+ * @param highlightedText (optional) a substring that, if present in [textString], should
+ * be highlighted with a color or bolded or something along those lines
+ */
 class SearchTextCellViewModel(val textString: String, highlightedText: String = "") : SearchBaseCellViewModel() {
     val text: Subject<Pair<String,String>> = BehaviorSubject.createDefault(Pair(textString, highlightedText))
     override fun equals(other: Any?): Boolean {

--- a/search/src/main/java/artic/edu/search/SearchResultsAdapter.kt
+++ b/search/src/main/java/artic/edu/search/SearchResultsAdapter.kt
@@ -76,16 +76,11 @@ class SearchResultsAdapter : AutoHolderRecyclerViewAdapter<SearchBaseCellViewMod
                             if (highlightedText.isEmpty()) {
                                 return@map text
                             } else {
-                                val startIndex = text.indexOf(string = highlightedText, ignoreCase = true)
-                                val string = SpannableString(text)
-                                if (startIndex > -1) {
-                                    string.setSpan(
-                                            StyleSpan(Typeface.BOLD),
-                                            startIndex,
-                                            startIndex + highlightedText.length,
-                                            Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-                                }
-                                return@map string
+                                val withSpans = SpannableString(text)
+
+                                applyHighlight(withSpans, highlightedText)
+
+                                return@map withSpans
                             }
                         }
                         .bindTo(suggestedKeyword.text())
@@ -111,6 +106,21 @@ class SearchResultsAdapter : AutoHolderRecyclerViewAdapter<SearchBaseCellViewMod
             else -> {
 
             }
+        }
+    }
+
+    /**
+     * Marks out the section of [target] matching [highlightedText] in bold.
+     */
+    private fun applyHighlight(target: SpannableString, highlightedText: String) {
+        val startIndex = target.indexOf(string = highlightedText, ignoreCase = true)
+        if (startIndex > -1) {
+            target.setSpan(
+                    StyleSpan(Typeface.BOLD),
+                    startIndex,
+                    startIndex + highlightedText.length,
+                    Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+            )
         }
     }
 


### PR DESCRIPTION
This covers the application of *bold* text to the search query, in the first position found for it to exist. Previously if the same search result stuck around while you typed the *bold* span wouldn't change.