### PR TITLE
Refactors search to map flow (AIC-163)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
@@ -1,6 +1,7 @@
 package edu.artic.map
 
 import edu.artic.db.models.ArticObject
+import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.db.models.ArticTour
 
 data class MapChangeEvent(val focus: MapFocus, val floor: Int, val displayMode: MapDisplayMode)
@@ -51,7 +52,7 @@ sealed class MapDisplayMode {
     data class Tour(val tour: ArticTour, val selectedTourStop: ArticTour.TourStop?) : MapDisplayMode()
     object CurrentFloor : MapDisplayMode()
     sealed class Search<T>(val item: T) : MapDisplayMode() {
-        class ObjectSearch(item: ArticObject) : Search<ArticObject>(item)
+        class ObjectSearch(item: ArticSearchArtworkObject) : Search<ArticSearchArtworkObject>(item)
         class AmenitiesSearch(amenityType: String) : Search<String>(amenityType)
     }
 }

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -61,8 +61,8 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private var mapClicks: Subject<Boolean> = PublishSubject.create()
     private var leaveTourDialog: LeaveCurrentTourDialogFragment? = null
 
-    private fun getLatestSearchObject(): ArticObject? {
-        val data: ArticObject? = requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
+    private fun getLatestSearchObject(): ArticSearchArtworkObject? {
+        val data: ArticSearchArtworkObject? = requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
         requireActivity().intent?.removeExtra(ARG_SEARCH_OBJECT)
         return data
     }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -359,7 +359,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     /**
      * Loads display mode for the map.
      */
-    fun onResume(requestedTour: ArticTour?, requestedTourStop: ArticTour.TourStop?, searchedObject: ArticObject?, searchedAnnotationType: String?) {
+    fun onResume(requestedTour: ArticTour?, requestedTourStop: ArticTour.TourStop?, searchedObject: ArticSearchArtworkObject?, searchedAnnotationType: String?) {
 
         /**
          * Store the search object to memory.

--- a/map/src/main/kotlin/edu/artic/map/SearchManager.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchManager.kt
@@ -3,6 +3,7 @@ package edu.artic.map
 import com.fuzz.rx.Optional
 import edu.artic.db.models.ArticMapAnnotation
 import edu.artic.db.models.ArticObject
+import edu.artic.db.models.ArticSearchArtworkObject
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
@@ -16,7 +17,7 @@ class SearchManager {
     /**
      * Selected ArticObject
      */
-    val selectedObject: Subject<Optional<ArticObject>> = BehaviorSubject.createDefault(Optional(null))
+    val selectedObject: Subject<Optional<ArticSearchArtworkObject>> = BehaviorSubject.createDefault(Optional(null))
     /**
      * Save the last selected tour.
      */

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
@@ -12,7 +12,7 @@ import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import edu.artic.adapter.toPagerAdapter
 import edu.artic.analytics.ScreenCategoryName
-import edu.artic.db.models.ArticObject
+import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.ui.getAudioServiceObservable
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -146,7 +146,7 @@ class SearchObjectDetailsFragment : BaseViewModelFragment<SearchObjectDetailsVie
         private val ARG_SEARCH_OBJECT = "ARG_SEARCH_OBJECT"
         private val ARG_AMENITY_TYPE = "ARG_AMENITY_TYPE"
 
-        fun loadArtworkResults(articObject: ArticObject): SearchObjectDetailsFragment {
+        fun loadArtworkResults(articObject: ArticSearchArtworkObject): SearchObjectDetailsFragment {
             return SearchObjectDetailsFragment().apply {
                 arguments = Bundle().apply {
                     putParcelable(ARG_SEARCH_OBJECT, articObject)
@@ -163,8 +163,8 @@ class SearchObjectDetailsFragment : BaseViewModelFragment<SearchObjectDetailsVie
         }
     }
 
-    private fun getLatestTourObject(): ArticObject? {
-        val data = arguments?.getParcelable<ArticObject>(ARG_SEARCH_OBJECT)
+    private fun getLatestTourObject(): ArticSearchArtworkObject? {
+        val data = arguments?.getParcelable<ArticSearchArtworkObject>(ARG_SEARCH_OBJECT)
         arguments?.remove(ARG_SEARCH_OBJECT)
         return data
 

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
@@ -158,6 +158,7 @@ class ArtworkViewModel(val item: ArticSearchArtworkObject, val languageSelector:
     val objectType: Subject<String> = BehaviorSubject.createDefault("Artworks")
     private val audioFileModel = item.audioObject?.audioFile?.preferredLanguage(languageSelector)
     val playState: Subject<AudioPlayerService.PlayBackState> = BehaviorSubject.create()
+    val hasAudio: Subject<Boolean> = BehaviorSubject.createDefault(item.audioObject != null)
 
     init {
         imageUrl.onNext(item.thumbUrl.orEmpty())

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
@@ -53,7 +53,7 @@ class SearchObjectDetailsViewModel @Inject constructor(val languageSelector: Lan
     /**
      * when the search type is amenities fetch all the amenities and create viewmodels
      */
-    fun viewResumed(requestedSearchObject: ArticObject?, requestedSearchAmenityType: String?) {
+    fun viewResumed(requestedSearchObject: ArticSearchArtworkObject?, requestedSearchAmenityType: String?) {
 
         /**
          * latestTourObject and amenityType are mutually exclusive
@@ -147,7 +147,7 @@ class AnnotationViewModel(item: String, modelDescription: String) : SearchObject
 /**
  * ViewModel for the artwork cell.
  */
-class ArtworkViewModel(val item: ArticObject, val languageSelector: LanguageSelector) : SearchObjectBaseViewModel() {
+class ArtworkViewModel(val item: ArticSearchArtworkObject, val languageSelector: LanguageSelector) : SearchObjectBaseViewModel() {
 
     val artworkTitle: Subject<String> = BehaviorSubject.createDefault(item.title)
 
@@ -156,7 +156,7 @@ class ArtworkViewModel(val item: ArticObject, val languageSelector: LanguageSele
 
     //TODO:: Localize Artworks
     val objectType: Subject<String> = BehaviorSubject.createDefault("Artworks")
-    private val audioFileModel = item.audioFile?.preferredLanguage(languageSelector)
+    private val audioFileModel = item.audioObject?.audioFile?.preferredLanguage(languageSelector)
     val playState: Subject<AudioPlayerService.PlayBackState> = BehaviorSubject.create()
 
     init {
@@ -176,7 +176,9 @@ class ArtworkViewModel(val item: ArticObject, val languageSelector: LanguageSele
      * Play the audio translation for the selected artwork.
      */
     fun playAudioTranslation() {
-        playerControl.onNext(PlayerAction.Play(item, audioFileModel))
+        item.audioObject?.let {
+            playerControl.onNext(PlayerAction.Play(it, audioFileModel))
+        }
 
     }
 

--- a/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchedObjectsAdapter.kt
@@ -110,6 +110,9 @@ class SearchedObjectsAdapter : AutoHolderRecyclerViewAdapter<SearchObjectBaseVie
                     }
                 }.disposedBy(item.viewDisposeBag)
 
+                item.hasAudio
+                        .bindToMain(playCurrent.visibility())
+                        .disposedBy(item.viewDisposeBag)
             }
         }
     }

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -2,6 +2,7 @@ package edu.artic.map.rendering
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
+import com.fuzz.rx.asFlowable
 import com.fuzz.rx.disposedBy
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
@@ -12,15 +13,8 @@ import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.models.ArticObject
 import edu.artic.image.asRequestObservable
 import edu.artic.image.loadWithThumbnail
-import edu.artic.map.ArticObjectMarkerGenerator
-import edu.artic.map.MapChangeEvent
-import edu.artic.map.MapDisplayMode
-import edu.artic.map.MapFocus
-import edu.artic.map.R
-import edu.artic.map.getTourOrderNumberBasedOnDisplayMode
+import edu.artic.map.*
 import edu.artic.map.helpers.toLatLng
-import edu.artic.map.isCloseEnoughToCenter
-import edu.artic.ui.util.asCDNUri
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Observable
@@ -140,7 +134,13 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
     override fun getItems(floor: Int, displayMode: MapDisplayMode): Flowable<List<ArticObject>> = when (displayMode) {
         is MapDisplayMode.CurrentFloor -> objectsDao.getObjectsByFloor(floor = floor)
         is MapDisplayMode.Tour -> objectsDao.getObjectsByIdList(displayMode.tour.tourStops.mapNotNull { it.objectId })
-        is MapDisplayMode.Search.ObjectSearch -> objectsDao.getObjectById(displayMode.item.nid).map { listOf(it) }
+        is MapDisplayMode.Search.ObjectSearch -> {
+            if (displayMode.item.audioObject != null) {
+                listOf(displayMode.item.audioObject as ArticObject).asFlowable()
+            } else {
+                listOf<ArticObject>().asFlowable()
+            }
+        }
         is MapDisplayMode.Search.AmenitiesSearch -> listOf<List<ArticObject>>().toFlowable()
     }
 

--- a/search/src/main/java/edu/artic/search/SearchAudioDetailFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchAudioDetailFragment.kt
@@ -128,13 +128,12 @@ class SearchAudioDetailFragment : BaseViewModelFragment<SearchAudioDetailViewMod
                 .subscribe {
                     when (it.endpoint) {
                         is SearchAudioDetailViewModel.NavigationEndpoint.ObjectOnMap -> {
-                            val o = (it.endpoint as SearchAudioDetailViewModel.NavigationEndpoint.ObjectOnMap).articObject
+                            val o: ArticSearchArtworkObject = (it.endpoint as SearchAudioDetailViewModel.NavigationEndpoint.ObjectOnMap).articObject
                             val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
                                 putExtra(NavigationConstants.ARG_SEARCH_OBJECT, o)
                                 flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
                             }
-                            //TODO: update map to handle ArticSearchArtworkObject
-//                            startActivity(mapIntent)
+                            startActivity(mapIntent)
                         }
                     }
                 }.disposedBy(navigationDisposeBag)

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -9,6 +9,7 @@ import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemClicksWithPosition
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.asDeepLinkIntent
+import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.exhibitions.ExhibitionDetailFragment
 import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
@@ -84,7 +85,7 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
                     val searchNavController = Navigation.findNavController(requireActivity(), R.id.container)
                     when (it.endpoint) {
                         is SearchBaseViewModel.NavigationEndpoint.ArtworkOnMap -> {
-                            val o = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.ArtworkOnMap).articObject
+                            val o: ArticSearchArtworkObject = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.ArtworkOnMap).articObject
                             val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
                                 putExtra(NavigationConstants.ARG_SEARCH_OBJECT, o)
                                 flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -93,20 +93,21 @@ open class SearchBaseViewModel @Inject constructor(
                 navigateTo.onNext(Navigate.Forward(NavigationEndpoint.Web))
             }
             is SearchCircularCellViewModel -> {
-                viewModel.artWork?.let { arcticObject ->
-                    /* Convert the ArcticObject to ArcticSearchArtworkObject*/
-                    val arcticSearchArtworkObject = ArticSearchArtworkObject(
-                            artworkId = arcticObject.id.toString(),
-                            audioObject = arcticObject,
-                            title = arcticObject.title,
-                            thumbnailUrl = arcticObject.thumbUrl,
-                            imageUrl = arcticObject.largeImageUrl,
-                            artistDisplay = arcticObject.artistCulturePlaceDelim,
-                            location = arcticObject.location,
-                            floor = arcticObject.floor,
-                            gallery = null)
+                viewModel.artWork?.let { articObject ->
+                    /** Convert the [ArticObject] to [ArticSearchArtworkObject] **/
+                    val articSearchArtworkObject = ArticSearchArtworkObject(
+                            artworkId = articObject.id.toString(),
+                            audioObject = articObject,
+                            title = articObject.title,
+                            thumbnailUrl = articObject.thumbUrl,
+                            imageUrl = articObject.largeImageUrl,
+                            artistDisplay = articObject.artistCulturePlaceDelim,
+                            location = articObject.location,
+                            floor = articObject.floor,
+                            gallery = null /* Currently, gallery is not required for search details */
+                    )
 
-                    navigateTo.onNext(Navigate.Forward(NavigationEndpoint.ArtworkOnMap(arcticSearchArtworkObject)))
+                    navigateTo.onNext(Navigate.Forward(NavigationEndpoint.ArtworkOnMap(articSearchArtworkObject)))
                 }
             }
             is SearchTextCellViewModel -> {

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -5,7 +5,6 @@ import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.db.models.ArticExhibition
-import edu.artic.db.models.ArticObject
 import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.db.models.ArticTour
 import edu.artic.viewmodel.NavViewViewModel
@@ -23,7 +22,7 @@ open class SearchBaseViewModel @Inject constructor(
         data class TourDetails(val tour: ArticTour) : NavigationEndpoint()
         data class ExhibitionDetails(val exhibition: ArticExhibition) : NavigationEndpoint()
         data class ArtworkDetails(val articObject: ArticSearchArtworkObject) : NavigationEndpoint()
-        data class ArtworkOnMap(val articObject: ArticObject) : NavigationEndpoint()
+        data class ArtworkOnMap(val articObject: ArticSearchArtworkObject) : NavigationEndpoint()
         data class AmenityOnMap(val type: SuggestedMapAmenities) : NavigationEndpoint()
         object Web : NavigationEndpoint()
 
@@ -94,13 +93,20 @@ open class SearchBaseViewModel @Inject constructor(
                 navigateTo.onNext(Navigate.Forward(NavigationEndpoint.Web))
             }
             is SearchCircularCellViewModel -> {
-                viewModel.artWork?.let { articObject ->
-                    navigateTo.onNext(
-                            Navigate.Forward(
-                                    NavigationEndpoint.ArtworkOnMap(articObject)
-                            )
-                    )
+                viewModel.artWork?.let { arcticObject ->
+                    /* Convert the ArcticObject to ArcticSearchArtworkObject*/
+                    val arcticSearchArtworkObject = ArticSearchArtworkObject(
+                            artworkId = arcticObject.id.toString(),
+                            audioObject = arcticObject,
+                            title = arcticObject.title,
+                            thumbnailUrl = arcticObject.thumbUrl,
+                            imageUrl = arcticObject.largeImageUrl,
+                            artistDisplay = arcticObject.artistCulturePlaceDelim,
+                            location = arcticObject.location,
+                            floor = arcticObject.floor,
+                            gallery = null)
 
+                    navigateTo.onNext(Navigate.Forward(NavigationEndpoint.ArtworkOnMap(arcticSearchArtworkObject)))
                 }
             }
             is SearchTextCellViewModel -> {


### PR DESCRIPTION
Updates:
* Refactors the way objects are sent to the map. `SearchObjectDetailsFragment` now only accepts the proxy object `ArticSearchArtworkObject`. 
* Hides the playback control from search details if no audio translation is available