### PR TITLE
Fixed on-map pins appear at the wrong zoom (AIC-433)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
@@ -112,6 +112,10 @@ data class ArticObject(
     }
 }
 
+/**
+ * Returns the primary audio track for this object. If there
+ * is no such audio, this will return null.
+ */
 val ArticObject.audioFile: ArticAudioFile?
     get() = this.audioCommentary.firstOrNull()?.audioFile
 

--- a/db/src/main/kotlin/edu/artic/db/models/ArticSearchArtworkObject.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticSearchArtworkObject.kt
@@ -6,12 +6,24 @@ import com.squareup.moshi.JsonClass
 import edu.artic.ui.util.asCDNUri
 import kotlinx.android.parcel.Parcelize
 
+/**
+ * Every ArticSearchArtworkObject is created off of a representative
+ * [ArticObject].
+ *
+ * In the Swift codebase that field is called `audioObject`, while here
+ * we refer to it as [backingObject].
+ */
 @JsonClass(generateAdapter = true)
 @Entity
 @Parcelize
 data class ArticSearchArtworkObject(
         val artworkId: String = "",
-        val audioObject: ArticObject? = null,
+        /**
+         * Use this to access the associated audio commentaries, if any are present.
+         *
+         * See [ArticObject.audioFile] for details.
+         */
+        val backingObject: ArticObject? = null,
         val title: String,
         val thumbnailUrl: String?,
         val imageUrl: String?,

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -238,13 +238,25 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.tourBoundsChanged
-                .withLatestFrom(viewModel.currentMap.filterValue())
+                .withLatestFrom(viewModel.currentMap.filterValue(), viewModel.displayMode)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeBy { (bounds, map) ->
-                    map.moveCamera(CameraUpdateFactory
-                            .newLatLngBounds(LatLngBounds.builder()
-                                    .includeAll(bounds)
-                                    .build(), 0))
+                .subscribeBy { (bounds, map, mode) ->
+
+                    if (mode is MapDisplayMode.Search<*>) {
+                        // Only need to zoom out all the way. Specific bounds are irrelevant
+                        map.animateCamera(
+                                CameraUpdateFactory.zoomTo(ZOOM_MIN)
+                        )
+                    } else {
+                        // Make sure we can see all of the specified positions
+                        map.moveCamera(CameraUpdateFactory
+                                .newLatLngBounds(
+                                        LatLngBounds.builder()
+                                                .includeAll(bounds)
+                                                .build(),
+                                        0
+                                ))
+                    }
                 }
                 .disposedBy(disposeBag)
 

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -237,7 +237,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 }
                 .disposedBy(disposeBag)
 
-        viewModel.tourBoundsChanged
+        viewModel.boundsOfInterestChanged
                 .withLatestFrom(viewModel.currentMap.filterValue(), viewModel.displayMode)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { (bounds, map, mode) ->

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -50,7 +50,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     val displayMode: Subject<MapDisplayMode> = PublishSubject.create()
     val selectedArticObject: Subject<ArticObject> = BehaviorSubject.create()
     val individualMapChange: Subject<Optional<Pair<LatLng, MapFocus>>> = PublishSubject.create()
-    val tourBoundsChanged: Relay<List<LatLng>> = PublishRelay.create()
+    val boundsOfInterestChanged: Relay<List<LatLng>> = PublishRelay.create()
     val currentMap: Subject<Optional<GoogleMap>> = BehaviorSubject.createDefault(Optional(null))
     val leaveTourRequest: Subject<Boolean> = PublishSubject.create()
     val leftActiveTour: Subject<Boolean> = PublishSubject.create()
@@ -237,7 +237,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         Observable.just(displayItem)
                 .filterFlatMap({ it is ArticSearchArtworkObject }, { it as ArticSearchArtworkObject })
                 .map { listOf(it.toLatLng()) }
-                .bindToMain(tourBoundsChanged)
+                .bindToMain(boundsOfInterestChanged)
                 .disposedBy(disposeBag)
 
         if (displayItem is ArticSearchArtworkObject) {
@@ -269,7 +269,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         }
 
         latLongs
-                .bindToMain(tourBoundsChanged)
+                .bindToMain(boundsOfInterestChanged)
                 .disposedBy(disposeBag)
     }
 

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -232,14 +232,18 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     }
 
     private fun animateToSearchItemBounds(displayMode: MapDisplayMode.Search<*>) {
-        Observable.just(displayMode.item)
-                .filterFlatMap({ it is ArticObject }, { it as ArticObject })
+        val displayItem = displayMode.item
+
+        Observable.just(displayItem)
+                .filterFlatMap({ it is ArticSearchArtworkObject }, { it as ArticSearchArtworkObject })
                 .map { listOf(it.toLatLng()) }
                 .bindToMain(tourBoundsChanged)
                 .disposedBy(disposeBag)
 
-        if (displayMode.item is ArticObject) {
-            articObjectSelected(displayMode.item)
+        if (displayItem is ArticSearchArtworkObject) {
+            displayItem.backingObject?.let {
+                articObjectSelected(it)
+            }
         }
     }
 

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsViewModel.kt
@@ -156,9 +156,9 @@ class ArtworkViewModel(val item: ArticSearchArtworkObject, val languageSelector:
 
     //TODO:: Localize Artworks
     val objectType: Subject<String> = BehaviorSubject.createDefault("Artworks")
-    private val audioFileModel = item.audioObject?.audioFile?.preferredLanguage(languageSelector)
+    private val audioFileModel = item.backingObject?.audioFile?.preferredLanguage(languageSelector)
     val playState: Subject<AudioPlayerService.PlayBackState> = BehaviorSubject.create()
-    val hasAudio: Subject<Boolean> = BehaviorSubject.createDefault(item.audioObject != null)
+    val hasAudio: Subject<Boolean> = BehaviorSubject.createDefault(item.backingObject != null)
 
     init {
         imageUrl.onNext(item.thumbUrl.orEmpty())
@@ -177,7 +177,7 @@ class ArtworkViewModel(val item: ArticSearchArtworkObject, val languageSelector:
      * Play the audio translation for the selected artwork.
      */
     fun playAudioTranslation() {
-        item.audioObject?.let {
+        item.backingObject?.let {
             playerControl.onNext(PlayerAction.Play(it, audioFileModel))
         }
 

--- a/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
+++ b/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
@@ -2,12 +2,20 @@ package edu.artic.map.helpers
 
 import com.google.android.gms.maps.model.LatLng
 import edu.artic.db.models.ArticObject
+import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.db.models.ArticTour
 
 /**
  * See [convertToLatLng].
  */
 fun ArticObject.toLatLng(): LatLng {
+    return convertToLatLng(location)
+}
+
+/**
+ * See [convertToLatLng].
+ */
+fun ArticSearchArtworkObject.toLatLng(): LatLng {
     return convertToLatLng(location)
 }
 

--- a/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
+++ b/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
@@ -1,25 +1,19 @@
 package edu.artic.map.helpers
 
-import android.support.annotation.UiThread
-import android.util.Log
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.Marker
 import edu.artic.db.models.ArticObject
 import edu.artic.db.models.ArticTour
-import edu.artic.map.BuildConfig
 
+/**
+ * See [convertToLatLng].
+ */
 fun ArticObject.toLatLng(): LatLng {
-    val split = location?.split(",")
-    return LatLng(
-            split?.first()?.toDouble() ?: 0.0,
-            split?.last()?.toDouble() ?: 0.0
-    )
+    return convertToLatLng(location)
 }
 
+/**
+ * See [convertToLatLng].
+ */
 fun ArticTour.toLatLng(): LatLng {
-    val split = location?.split(",")
-    return LatLng(
-            split?.first()?.toDouble() ?: 0.0,
-            split?.last()?.toDouble() ?: 0.0
-    )
+    return convertToLatLng(location)
 }

--- a/map/src/main/kotlin/edu/artic/map/helpers/LatLngExtensions.kt
+++ b/map/src/main/kotlin/edu/artic/map/helpers/LatLngExtensions.kt
@@ -1,0 +1,21 @@
+package edu.artic.map.helpers
+
+import com.google.android.gms.maps.model.LatLng
+
+/**
+ * Extension method to convert from a comma-separated string to a [LatLng]. Useful
+ * for [edu.artic.db.models.ArticObject] and similar models.
+ *
+ * Expected format:
+ *
+ *     50.123,-60.123
+ */
+fun convertToLatLng(location: String?): LatLng {
+    val split = location?.split(",")
+    return LatLng(
+            split?.first()?.toDouble() ?: 0.0,
+            split?.last()?.toDouble() ?: 0.0
+    )
+}
+
+

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -135,8 +135,8 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
         is MapDisplayMode.CurrentFloor -> objectsDao.getObjectsByFloor(floor = floor)
         is MapDisplayMode.Tour -> objectsDao.getObjectsByIdList(displayMode.tour.tourStops.mapNotNull { it.objectId })
         is MapDisplayMode.Search.ObjectSearch -> {
-            if (displayMode.item.audioObject != null) {
-                listOf(displayMode.item.audioObject as ArticObject).asFlowable()
+            if (displayMode.item.backingObject != null) {
+                listOf(displayMode.item.backingObject as ArticObject).asFlowable()
             } else {
                 listOf<ArticObject>().asFlowable()
             }

--- a/search/src/main/java/edu/artic/search/SearchAudioDetailViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchAudioDetailViewModel.kt
@@ -72,13 +72,13 @@ class SearchAudioDetailViewModel @Inject constructor(
                 .disposedBy(disposeBag)
 
         articObjectObservable
-                .filter { it.audioObject == null }
+                .filter { it.backingObject == null }
                 .map { false }
                 .bindTo(playAudioVisible)
                 .disposedBy(disposeBag)
 
         articObjectObservable
-                .filterFlatMap({ it.audioObject != null },{it.audioObject!!})
+                .filterFlatMap({ it.backingObject != null },{it.backingObject!!})
                 .map{
                     it.audioCommentary.isNotEmpty()
                 }
@@ -107,8 +107,8 @@ class SearchAudioDetailViewModel @Inject constructor(
 
     fun onClickPlayAudio() {
         playerService?.let {playerService ->
-            articObject?.audioObject?.audioFile?.allTranslations()?.let {
-                val articObject = articObject?.audioObject as Playable
+            articObject?.backingObject?.audioFile?.allTranslations()?.let {
+                val articObject = articObject?.backingObject as Playable
                 playerService.playPlayer(articObject, languageSelector.selectFrom(it))
             }
 

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -82,10 +82,12 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
                 .filter { it is Navigate.Forward }
                 .map { it as Navigate.Forward }
                 .subscribe {
+                    val endpoint: SearchBaseViewModel.NavigationEndpoint = it.endpoint
+
                     val searchNavController = Navigation.findNavController(requireActivity(), R.id.container)
-                    when (it.endpoint) {
+                    when (endpoint) {
                         is SearchBaseViewModel.NavigationEndpoint.ArtworkOnMap -> {
-                            val o: ArticSearchArtworkObject = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.ArtworkOnMap).articObject
+                            val o: ArticSearchArtworkObject = endpoint.articObject
                             val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
                                 putExtra(NavigationConstants.ARG_SEARCH_OBJECT, o)
                                 flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
@@ -93,28 +95,28 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
                             startActivity(mapIntent)
                         }
                         is SearchBaseViewModel.NavigationEndpoint.TourDetails -> {
-                            val o = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.TourDetails).tour
+                            val o = endpoint.tour
                             searchNavController.navigate(
                                     R.id.goToTourDetails,
                                     TourDetailsFragment.argsBundle(o)
                             )
                         }
                         is SearchBaseViewModel.NavigationEndpoint.ExhibitionDetails -> {
-                            val o = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.ExhibitionDetails).exhibition
+                            val o = endpoint.exhibition
                             searchNavController.navigate(
                                     R.id.goToExhibitionDetails,
                                     ExhibitionDetailFragment.argsBundle(o)
                             )
                         }
                         is SearchBaseViewModel.NavigationEndpoint.ArtworkDetails -> {
-                            val o = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.ArtworkDetails).articObject
+                            val o = endpoint.articObject
                             searchNavController.navigate(
                                     R.id.goToSearchAudioDetails,
                                     SearchAudioDetailFragment.argsBundle(o)
                             )
                         }
                         is SearchBaseViewModel.NavigationEndpoint.AmenityOnMap -> {
-                            val amenity = (it.endpoint as SearchBaseViewModel.NavigationEndpoint.AmenityOnMap).type
+                            val amenity = endpoint.type
                             val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
                                 putExtra(ARG_AMENITY_TYPE, amenity.type)
                                 flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -97,7 +97,7 @@ open class SearchBaseViewModel @Inject constructor(
                     /** Convert the [ArticObject] to [ArticSearchArtworkObject] **/
                     val articSearchArtworkObject = ArticSearchArtworkObject(
                             artworkId = articObject.id.toString(),
-                            audioObject = articObject,
+                            backingObject = articObject,
                             title = articObject.title,
                             thumbnailUrl = articObject.thumbUrl,
                             imageUrl = articObject.largeImageUrl,

--- a/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
@@ -59,7 +59,7 @@ open class SearchBaseListItemViewModel(isHeadphonesVisible: Boolean = false)
 }
 
 class SearchArtworkCellViewModel(val articObject: ArticSearchArtworkObject)
-    : SearchBaseListItemViewModel(isHeadphonesVisible = articObject.audioObject?.audioCommentary?.isNotEmpty() ?: false) {
+    : SearchBaseListItemViewModel(isHeadphonesVisible = articObject.backingObject?.audioCommentary?.isNotEmpty() ?: false) {
 
     init {
         imageUrl.onNext(articObject.thumbUrl.orEmpty())


### PR DESCRIPTION
This adds a bunch of map-related documentation and makes sure we only zoom out if a new search object is asked for.