### PR TITLE
Removes tour object from bundle once used (AIC-452)

### DIFF
--- a/base/src/main/java/edu/artic/base/utils/IntentExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/IntentExtensions.kt
@@ -1,0 +1,35 @@
+package edu.artic.base.utils
+
+import android.content.Intent
+import android.os.Parcelable
+
+/**
+ * File contains the extension methods for [Intent]
+ * @author Sameer Dhakal (Fuzz)
+ */
+
+/**
+ * Returns the parcelable with given key from extras then remove it.
+ * @param key : extras Key
+ * @return [Parcelable]
+ */
+fun <T : Parcelable> Intent?.removeAndReturnParcelable(key: String): T? {
+    return this?.let {
+        val data: T? = it.getParcelableExtra(key)
+        removeExtra(key)
+        return data
+    }
+}
+
+/**
+ * Returns the String with given key from extras then remove it.
+ * @param key : extras Key
+ * @return [String]
+ */
+fun Intent?.removeAndReturnString(key: String): String? {
+    return this?.let {
+        val data: String? = it.getStringExtra(key)
+        removeExtra(key)
+        return data
+    }
+}

--- a/map/src/main/kotlin/edu/artic/map/MapActivity.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapActivity.kt
@@ -29,22 +29,6 @@ class MapActivity : BaseActivity() {
     override val layoutResId: Int
         get() = R.layout.activity_map
 
-    companion object {
-        val ARG_TOUR = "ARG_TOUR"
-        val ARG_TOUR_START_STOP = "ARG_TOUR_START_STOP"
-
-        fun launchMapForTour(tour: ArticTour, articTourStop: ArticTour.TourStop): Intent {
-            return NavigationConstants.MAP.asDeepLinkIntent().apply {
-                flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
-                putExtras(Bundle().apply {
-                    putParcelable(ARG_TOUR, tour)
-                    articTourStop.let { putParcelable(ARG_TOUR_START_STOP, it) }
-                })
-            }
-        }
-
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -71,26 +71,30 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private var leaveTourDialog: LeaveCurrentTourDialogFragment? = null
 
     private fun getLatestSearchObject(): ArticSearchArtworkObject? {
-        val data: ArticSearchArtworkObject? = requireActivity().intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
-        requireActivity().intent?.removeExtra(ARG_SEARCH_OBJECT)
+        val intent = requireActivity().intent
+        val data: ArticSearchArtworkObject? = intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
+        intent?.removeExtra(ARG_SEARCH_OBJECT)
         return data
     }
 
     private fun getLatestSearchObjectType(): String? {
-        val data: String? = requireActivity().intent?.getStringExtra(ARG_AMENITY_TYPE)
-        requireActivity().intent?.removeExtra(ARG_AMENITY_TYPE)
+        val intent = requireActivity().intent
+        val data: String? = intent?.getStringExtra(ARG_AMENITY_TYPE)
+        intent?.removeExtra(ARG_AMENITY_TYPE)
         return data
     }
 
     private fun getLatestTourObject(): ArticTour? {
-        val tour: ArticTour? = requireActivity().intent?.getParcelableExtra(NavigationConstants.ARG_TOUR)
-        requireActivity().intent?.removeExtra(NavigationConstants.ARG_TOUR)
+        val intent = requireActivity().intent
+        val tour: ArticTour? = intent?.getParcelableExtra(NavigationConstants.ARG_TOUR)
+        intent?.removeExtra(NavigationConstants.ARG_TOUR)
         return tour
     }
 
     private fun getStartTourStop(): ArticTour.TourStop? {
-        val startStop: ArticTour.TourStop? = requireActivity().intent?.getParcelableExtra(NavigationConstants.ARG_TOUR_START_STOP)
-        requireActivity().intent?.removeExtra(NavigationConstants.ARG_TOUR_START_STOP)
+        val intent = requireActivity().intent
+        val startStop: ArticTour.TourStop? = intent?.getParcelableExtra(NavigationConstants.ARG_TOUR_START_STOP)
+        intent?.removeExtra(NavigationConstants.ARG_TOUR_START_STOP)
         return startStop
     }
 

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -1,8 +1,10 @@
 package edu.artic.map
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.Parcelable
 import android.support.annotation.UiThread
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
@@ -19,6 +21,8 @@ import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.globalLayouts
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.fileAsString
+import edu.artic.base.utils.removeAndReturnParcelable
+import edu.artic.base.utils.removeAndReturnString
 import edu.artic.base.utils.statusBarHeight
 import edu.artic.db.models.*
 import edu.artic.map.carousel.LeaveCurrentTourDialogFragment
@@ -29,9 +33,10 @@ import edu.artic.map.rendering.MapItemRenderer
 import edu.artic.map.rendering.MarkerMetaData
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.ui.getAudioServiceObservable
-import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
 import edu.artic.navigation.NavigationConstants.Companion.ARG_SEARCH_OBJECT
+import edu.artic.navigation.NavigationConstants.Companion.ARG_TOUR
+import edu.artic.navigation.NavigationConstants.Companion.ARG_TOUR_START_STOP
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -41,7 +46,6 @@ import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.fragment_map.*
-import timber.log.Timber
 import kotlin.reflect.KClass
 
 /**
@@ -71,31 +75,19 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     private var leaveTourDialog: LeaveCurrentTourDialogFragment? = null
 
     private fun getLatestSearchObject(): ArticSearchArtworkObject? {
-        val intent = requireActivity().intent
-        val data: ArticSearchArtworkObject? = intent?.getParcelableExtra(ARG_SEARCH_OBJECT)
-        intent?.removeExtra(ARG_SEARCH_OBJECT)
-        return data
+        return requireActivity().intent.removeAndReturnParcelable(ARG_SEARCH_OBJECT)
     }
 
     private fun getLatestSearchObjectType(): String? {
-        val intent = requireActivity().intent
-        val data: String? = intent?.getStringExtra(ARG_AMENITY_TYPE)
-        intent?.removeExtra(ARG_AMENITY_TYPE)
-        return data
+        return requireActivity().intent.removeAndReturnString(ARG_AMENITY_TYPE)
     }
 
     private fun getLatestTourObject(): ArticTour? {
-        val intent = requireActivity().intent
-        val tour: ArticTour? = intent?.getParcelableExtra(NavigationConstants.ARG_TOUR)
-        intent?.removeExtra(NavigationConstants.ARG_TOUR)
-        return tour
+        return requireActivity().intent.removeAndReturnParcelable(ARG_TOUR)
     }
 
     private fun getStartTourStop(): ArticTour.TourStop? {
-        val intent = requireActivity().intent
-        val startStop: ArticTour.TourStop? = intent?.getParcelableExtra(NavigationConstants.ARG_TOUR_START_STOP)
-        intent?.removeExtra(NavigationConstants.ARG_TOUR_START_STOP)
-        return startStop
+        return requireActivity().intent.removeAndReturnParcelable(ARG_TOUR_START_STOP)
     }
 
 
@@ -389,7 +381,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
         viewModel.navigateTo
                 .filterFlatMap({ it is Navigate.Forward }, { (it as Navigate.Forward).endpoint })
                 .subscribe {
-                    when(it) {
+                    when (it) {
                         MapViewModel.NavigationEndpoint.LocationPrompt -> {
                             navController.navigate(R.id.goToLocationPrompt)
                         }

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -29,6 +29,7 @@ import edu.artic.map.rendering.MapItemRenderer
 import edu.artic.map.rendering.MarkerMetaData
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.ui.getAudioServiceObservable
+import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
 import edu.artic.navigation.NavigationConstants.Companion.ARG_SEARCH_OBJECT
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -82,14 +83,14 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
     }
 
     private fun getLatestTourObject(): ArticTour? {
-        val tour: ArticTour? = requireActivity().intent?.getParcelableExtra(MapActivity.ARG_TOUR)
-        requireActivity().intent?.extras?.remove(MapActivity.ARG_TOUR)
+        val tour: ArticTour? = requireActivity().intent?.getParcelableExtra(NavigationConstants.ARG_TOUR)
+        requireActivity().intent?.removeExtra(NavigationConstants.ARG_TOUR)
         return tour
     }
 
     private fun getStartTourStop(): ArticTour.TourStop? {
-        val startStop: ArticTour.TourStop? = requireActivity().intent?.getParcelableExtra(MapActivity.ARG_TOUR_START_STOP)
-        requireActivity().intent?.extras?.remove(MapActivity.ARG_TOUR_START_STOP)
+        val startStop: ArticTour.TourStop? = requireActivity().intent?.getParcelableExtra(NavigationConstants.ARG_TOUR_START_STOP)
+        requireActivity().intent?.removeExtra(NavigationConstants.ARG_TOUR_START_STOP)
         return startStop
     }
 


### PR DESCRIPTION
Changes :
* Clears the tour object from the bundle.

Since tour object was not removed, the map was presented in tour mode every time the user returned to map (it occurred only when `MapFragment` was resumed). 