### PR TITLE
Select audio track from service (AIC-456)

### DIFF
--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -65,28 +65,17 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceDisconnected(name: ComponentName?) {
             boundService = null
-            viewModel.playable = null
+            viewModel.onServiceDisconnected()
         }
 
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val binder = service as AudioPlayerService.AudioPlayerServiceBinder
             boundService = binder.getService()
-            viewModel.playable = boundService?.playable
 
             boundService?.let {
                 audioPlayer.player = it.player
-                it.player.refreshPlayBackState()
 
-                // Register for updates
-                it.currentTrack
-                        .subscribeBy { translation ->
-                            viewModel.chosenAudioModel.onNext(translation)
-                        }.disposedBy(disposeBag)
-
-                if (it.hasNoTrack()) {
-                    // Set up the default language selection.
-                    viewModel.chooseDefaultLanguage()
-                }
+                viewModel.onServiceConnected(it)
             }
         }
     }

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
 import android.view.View
-import android.widget.Spinner
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.fuzz.rx.bindToMain
@@ -15,18 +14,14 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.itemSelections
 import com.jakewharton.rxbinding2.widget.text
-import edu.artic.adapter.BaseRecyclerViewAdapter
-import edu.artic.adapter.BaseViewHolder
-import edu.artic.adapter.baseRecyclerViewAdapter
-import edu.artic.adapter.itemChanges
-import edu.artic.adapter.toBaseAdapter
+import edu.artic.adapter.*
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.updateDetailTitle
 import edu.artic.db.models.AudioFileModel
 import edu.artic.image.listenerAnimateSharedTransaction
-import edu.artic.media.audio.AudioPlayerService
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
+import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.refreshPlayBackState
 import edu.artic.viewmodel.BaseViewModelFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -81,6 +76,17 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
             boundService?.let {
                 audioPlayer.player = it.player
                 it.player.refreshPlayBackState()
+
+                // Register for updates
+                it.currentTrack
+                        .subscribeBy { translation ->
+                            viewModel.chosenAudioModel.onNext(translation)
+                        }.disposedBy(disposeBag)
+
+                if (it.hasNoTrack()) {
+                    // Set up the default language selection.
+                    viewModel.chooseDefaultLanguage()
+                }
             }
         }
     }

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsFragment.kt
@@ -22,7 +22,6 @@ import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
 import edu.artic.media.audio.AudioPlayerService
-import edu.artic.media.refreshPlayBackState
 import edu.artic.viewmodel.BaseViewModelFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.subscribeBy
@@ -150,7 +149,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
     private fun bindTranslationSelector(viewModel: AudioDetailsViewModel) {
 
-        viewModel.chosenAudioModel
+        viewModel.audioTrackToUse
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { chosen ->
                     exo_translation_selector.setSelection(translationsAdapter.itemIndexOf(chosen))

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
@@ -72,20 +72,12 @@ class AudioDetailsViewModel @Inject constructor(val languageSelector: LanguageSe
 
 
         // Retrieve a list of all translations we have available for this object
-        val known = objectObservable
+        objectObservable
                 .filterFlatMap({ it is ArticObject }, { it as ArticObject })
                 .map {
                     it.audioFile?.allTranslations().orEmpty()
-                }.share()
-
-        known.bindTo(availableTranslations)
-                .disposedBy(disposeBag)
-
-        // Set up the default language selection.
-        known.map {
-            // TODO: inject 'edu.artic.map.carousel.TourProgressManager', use that state as boolean
-            languageSelector.selectFrom(it, true)
-        }.bindTo(chosenAudioModel)
+                }
+                .bindTo(availableTranslations)
                 .disposedBy(disposeBag)
 
 
@@ -113,6 +105,19 @@ class AudioDetailsViewModel @Inject constructor(val languageSelector: LanguageSe
      */
     fun setTranslationOverride(audioModel: AudioFileModel) {
         chosenAudioModel.onNext(audioModel)
+    }
+
+    /**
+     * Only call this if the [edu.artic.media.audio.AudioPlayerService] itself is not
+     * defining the language for us.
+     */
+    fun chooseDefaultLanguage() {
+        availableTranslations
+                .map {
+                    // TODO: inject 'edu.artic.map.carousel.TourProgressManager', use that state as boolean
+                    languageSelector.selectFrom(it, true)
+                }.bindTo(chosenAudioModel)
+                .disposedBy(disposeBag)
     }
 
 }

--- a/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioDetailsViewModel.kt
@@ -165,6 +165,7 @@ class AudioDetailsViewModel @Inject constructor(val languageSelector: LanguageSe
      */
     private fun chooseDefaultLanguage() {
         availableTranslations
+                .take(1)
                 .map {
                     // TODO: inject 'edu.artic.map.carousel.TourProgressManager', use that state as boolean
                     languageSelector.selectFrom(it, true)

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -157,6 +157,9 @@ class AudioPlayerService : DaggerService(), PlayerService {
     lateinit var languageSelector: LanguageSelector
 
 
+    /**
+     * Something with one or more audio tracks. See [currentTrack] and [AudioFileModel].
+     */
     var playable: Playable? = null
         private set
 
@@ -359,6 +362,17 @@ class AudioPlayerService : DaggerService(), PlayerService {
         playerNotificationManager.setPlayer(null)
         player.release()
         disposeBag.dispose()
+    }
+
+    /**
+     * Counterpart to [switchAudioTrack]. When this returns true
+     *
+     * 1. [playable] is null
+     * 2. we expect (but do not guarantee) that [player] is in
+     * the [idle state][Player.STATE_IDLE]
+     */
+    fun hasNoTrack(): Boolean {
+        return !(currentTrack as BehaviorSubject).hasValue()
     }
 
     /**


### PR DESCRIPTION
This ensures that the current audio track is not changed simply because we've navigated to the audio details screen.

To assist in this, it moves most `AudioPlayerService` property detection (i.e. is something playing, what is playing, what language it is playing in, etc.) to the `AudioDetailsViewModel`.