### PR TITLE
Fade in markers on floor change (AIC-288)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -14,6 +14,7 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.Marker
 import edu.artic.base.utils.statusBarHeight
 import edu.artic.db.models.ArticObject
+import edu.artic.map.rendering.ALPHA_INVISIBLE
 
 
 /**
@@ -95,14 +96,14 @@ fun <T> Marker.tryExpectingFailure(retry: Boolean = false, action: (Marker) -> T
 }
 
 /**
- * This calls [Marker.remove] after animating the [alpha][MARKER_ALPHA] to 0 -
+ * This calls [Marker.remove] after animating the [alpha][MARKER_ALPHA] to [ALPHA_INVISIBLE] -
  * essentially, fully fading it out.
  *
  * Similar concept to [android.transition.Fade].
  */
 @UiThread
 fun Marker.removeWithFadeOut() {
-    val fadeOut: ObjectAnimator = ObjectAnimator.ofFloat(this, MARKER_ALPHA, 1f, 0f)
+    val fadeOut: ObjectAnimator = ObjectAnimator.ofFloat(this, MARKER_ALPHA, alpha, ALPHA_INVISIBLE)
     fadeOut.addListener(object : AnimatorListenerAdapter() {
         override fun onAnimationEnd(animation: Animator?) {
             tryExpectingFailure(true) {

--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -15,6 +15,7 @@ import com.google.android.gms.maps.model.Marker
 import edu.artic.base.utils.statusBarHeight
 import edu.artic.db.models.ArticObject
 import edu.artic.map.rendering.ALPHA_INVISIBLE
+import edu.artic.map.rendering.ALPHA_VISIBLE
 
 
 /**
@@ -96,8 +97,21 @@ fun <T> Marker.tryExpectingFailure(retry: Boolean = false, action: (Marker) -> T
 }
 
 /**
+ * Fade this Marker from its current alpha/transparency value to [finalAlpha].
+ *
+ * May be paired with [removeWithFadeOut]. Always starts with
+ * [the current value][MARKER_ALPHA], so for a complete fade-in effect you should set
+ * that to [ALPHA_INVISIBLE] before calling this.
+ */
+@UiThread
+fun Marker.fadeIn(finalAlpha: Float = ALPHA_VISIBLE) {
+    val fadeIn: ObjectAnimator = ObjectAnimator.ofFloat(this, MARKER_ALPHA, alpha, finalAlpha)
+    fadeIn.start()
+}
+
+/**
  * This calls [Marker.remove] after animating the [alpha][MARKER_ALPHA] to [ALPHA_INVISIBLE] -
- * essentially, fully fading it out.
+ * essentially, fully fading it out. Counterpart to [fadeIn].
  *
  * Similar concept to [android.transition.Fade].
  */

--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -19,6 +19,14 @@ import edu.artic.map.rendering.ALPHA_VISIBLE
 
 
 /**
+ * Preferred default duration for fading in/out [MARKER_ALPHA].
+ *
+ * Since we're using [ObjectAnimator]s, this overrides the default
+ * of `300 milliseconds`.
+ */
+internal const val MARKER_FADE_DURATION: Long = 500L
+
+/**
  * Reference instance of [AlphaProperty]. Use this
  * to animate [Marker.setAlpha] and [Marker.getAlpha].
  *
@@ -106,6 +114,7 @@ fun <T> Marker.tryExpectingFailure(retry: Boolean = false, action: (Marker) -> T
 @UiThread
 fun Marker.fadeIn(finalAlpha: Float = ALPHA_VISIBLE) {
     val fadeIn: ObjectAnimator = ObjectAnimator.ofFloat(this, MARKER_ALPHA, alpha, finalAlpha)
+    fadeIn.duration = MARKER_FADE_DURATION
     fadeIn.start()
 }
 
@@ -125,6 +134,7 @@ fun Marker.removeWithFadeOut() {
             }
         }
     })
+    fadeOut.duration = MARKER_FADE_DURATION
     fadeOut.start()
 }
 

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -323,7 +323,14 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
         /**
          * Center the full object marker in the map.
-         * When we are in [DisplayMode.Tour] and if the item is being centered, always reset the zoom level to MapZoomLevel.Three
+         *
+         * When we are in [MapDisplayMode.Tour] and the item is being centered, we always
+         * need to reset the zoom level to [ZOOM_INDIVIDUAL] - we subscribe to
+         * [MapViewModel.selectedTourStopMarkerId] here to detect that scenario.
+         *
+         * Other [MapDisplayMode]s share the [MapViewModel.selectedArticObject] field, so
+         * a single subscription on [MapViewModel.boundsOfInterestChanged] higher-up in
+         * this function handles all that.
          */
         viewModel
                 .selectedTourStopMarkerId

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -387,6 +387,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
     fun visibleRegionChanged(visibleRegion: VisibleRegion) {
         // only emit if visible region is not locked.
         lockVisibleRegion
+                .take(1)
                 .filter { !it }
                 .subscribeBy {
                     visibleRegionChanges.onNext(visibleRegion)

--- a/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
+++ b/map/src/main/kotlin/edu/artic/map/helpers/ArticObjectExtension.kt
@@ -7,6 +7,9 @@ import edu.artic.db.models.ArticTour
 
 /**
  * See [convertToLatLng].
+ *
+ * When interacting with [MapItemRenderers][edu.artic.map.rendering.MapItemRenderer],
+ * consider using `getAdjustedLocationFromItem` instead.
  */
 fun ArticObject.toLatLng(): LatLng {
     return convertToLatLng(location)

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
@@ -381,20 +381,26 @@ abstract class MapItemRenderer<T>(
             loadedBitmap: Boolean,
             requestDisposable: Disposable?
     ): MarkerHolder<T> {
+        val targetAlpha = getMarkerAlpha(floor,
+                displayMode,
+                item)
+
         val options = MarkerOptions()
                 .zIndex(zIndex)
                 .position(getAdjustedLocationFromItem(item))
                 .icon(bitmap)
-                .alpha(getMarkerAlpha(floor,
-                        displayMode,
-                        item)
-                )
-        return MarkerHolder(
+                .alpha(0f)
+
+        val markerHolder = MarkerHolder(
                 id,
                 item,
                 map.addMarker(options).apply {
                     tag = MarkerMetaData(item, loadedBitmap, requestDisposable)
                 })
+
+        markerHolder.marker.fadeIn(targetAlpha)
+
+        return markerHolder
     }
 
 }

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
@@ -10,6 +10,7 @@ import com.fuzz.rx.filterValue
 import com.fuzz.rx.optionalOf
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.*
+import edu.artic.db.INVALID_FLOOR
 import edu.artic.db.debug
 import edu.artic.map.*
 import io.reactivex.BackpressureStrategy
@@ -40,7 +41,7 @@ abstract class MapItemRenderer<T>(
 
     protected val mapItems: Subject<Map<String, MarkerHolder<T>>> = BehaviorSubject.createDefault(emptyMap())
     private val currentMap: Subject<Optional<GoogleMap>> = BehaviorSubject.createDefault(Optional(null))
-    private var currentFloor: Int = Int.MIN_VALUE
+    private var currentFloor: Int = INVALID_FLOOR
 
     protected val imageQueueDisposeBag = DisposeBag()
     private val imageFetcherDisposeBag = DisposeBag()

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
@@ -1,6 +1,8 @@
 package edu.artic.map.rendering
 
 import android.content.Context
+import android.support.annotation.AnyThread
+import android.support.annotation.UiThread
 import com.fuzz.rx.DisposeBag
 import com.fuzz.rx.Optional
 import com.fuzz.rx.asFlowable
@@ -146,6 +148,7 @@ abstract class MapItemRenderer<T>(
      * but depending on mode, this might be [ALPHA_DIMMED]. If for example, we're on tour and displaying
      * a different floor than current.
      */
+    @AnyThread
     open fun getMarkerAlpha(floor: Int, mapDisplayMode: MapDisplayMode, item: T): Float = ALPHA_VISIBLE
 
     fun getMarkerHolderById(id: String): Observable<Optional<MarkerHolder<T>>> =
@@ -242,6 +245,7 @@ abstract class MapItemRenderer<T>(
      * any delayed markers with [enqueueBitmapFetch]. If marker exists on map currently we reuse it
      * and adjust alpha, if needed.
      */
+    @UiThread
     private fun mapAndFetchDisplayMarkers(foundItemsMap: Map<String, MarkerHolder<T>>,
                                           mapRenderEvent: MapItemRendererEvent<T>,
                                           visibleRegion: VisibleRegion): List<MarkerHolder<T>> {
@@ -266,12 +270,14 @@ abstract class MapItemRenderer<T>(
     /**
      * Perform custom marker changes when visible.
      */
+    @UiThread
     protected open fun adjustVisibleMarker(
             existing: MarkerHolder<T>,
             visibleRegion: VisibleRegion,
             mapChangeEvent: MapChangeEvent
     ) = Unit
 
+    @UiThread
     protected open fun displayMarker(item: T,
                                      mapChangeEvent: MapChangeEvent,
                                      visibleRegion: VisibleRegion,
@@ -364,6 +370,7 @@ abstract class MapItemRenderer<T>(
      * Constructs the [MarkerHolder] based on a few parameters. Also adds the [MarkerHolder] to
      * the [GoogleMap].
      */
+    @UiThread
     internal fun constructAndAddMarkerHolder(
             item: T,
             bitmap: BitmapDescriptor?,

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
@@ -20,6 +20,7 @@ import edu.artic.map.helpers.toLatLng
 import io.reactivex.Flowable
 import io.reactivex.Observable
 
+internal const val ALPHA_INVISIBLE = 0.0f
 internal const val ALPHA_DIMMED = 0.6f
 internal const val ALPHA_VISIBLE = 1.0f
 

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -105,7 +105,7 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
             floor: Int,
             id: String
     ): MarkerHolder<ArticObject>? {
-        val position = item.toLatLng()
+        val position = getAdjustedLocationFromItem(item)
         var requestDisposable: Disposable? = null
 
         // slightly different logic than the above method. If close enough to center or on tour, enqueue and show loading.


### PR DESCRIPTION
I think the timing of the animations may need a little work. For now, I've set a duration of 500 milliseconds even though the Swift code (in [MapView.swift](https://github.com/art-institute-of-chicago/aic-mobile-ios/blob/0b08e746ca92e/aic/aic/ViewControllers%2BViews/Sections/Map/MapView.swift)) uses 250 milliseconds. More critical though is the actual code changes:

1. Create and use a new `Marker::fadeIn` function
2. Deduplication of visible region changes (prevents stale region info from sticking around)
3. Properly adjust item coords before checking if they're on-screen
4. Small yet handy updates to documentation

Item 3. gave me the most grief - it's the code change in `ObjectsMapItemRenderer.kt` line 108. This logic is irrelevant when there's a constant stream of updates, like when the map's being dragged around. But if you switch floors it is absolutely crucial to detecting which objects need to be drawn with full markers and which should be little dots.