### PR TITLE
Fade tile overlays in and out

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -12,12 +12,22 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.TileOverlay
 import edu.artic.base.utils.statusBarHeight
 import edu.artic.db.models.ArticObject
 import edu.artic.map.rendering.ALPHA_INVISIBLE
 import edu.artic.map.rendering.ALPHA_VISIBLE
+import edu.artic.map.rendering.TRANSPARENCY_INVISIBLE
+import edu.artic.map.rendering.TRANSPARENCY_VISIBLE
 
 
+/**
+ * Preferred default duration for fading in/out [OVERLAY_TRANSPARENCY].
+ *
+ * Since we're using [ObjectAnimator]s, this overrides the default
+ * of `300 milliseconds`.
+ */
+internal const val OVERLAY_FADE_DURATION: Long = 900L
 /**
  * Preferred default duration for fading in/out [MARKER_ALPHA].
  *
@@ -34,6 +44,12 @@ internal const val MARKER_FADE_DURATION: Long = 500L
  */
 val MARKER_ALPHA: Property<Marker, Float> = AlphaProperty()
 
+/**
+ * Reference instance of [TransparencyProperty]. Use this
+ * to animate [TileOverlay.setTransparency] and [TileOverlay.getTransparency].
+ */
+val OVERLAY_TRANSPARENCY: Property<TileOverlay, Float> = TransparencyProperty()
+
 internal class AlphaProperty : Property<Marker, Float>(Float::class.java, "alpha") {
     override fun get(given: Marker?): Float {
         return given?.alpha ?: Float.NaN
@@ -44,6 +60,15 @@ internal class AlphaProperty : Property<Marker, Float>(Float::class.java, "alpha
     }
 }
 
+internal class TransparencyProperty : Property<TileOverlay, Float>(Float::class.java, "transparency") {
+    override fun get(given: TileOverlay?): Float {
+        return given?.transparency ?: Float.NaN
+    }
+
+    override fun set(given: TileOverlay?, value: Float) {
+        given?.transparency = value
+    }
+}
 
 /**
  * We only want to display [ArticObject] annotations that are within 15 meters

--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -47,6 +47,8 @@ val MARKER_ALPHA: Property<Marker, Float> = AlphaProperty()
 /**
  * Reference instance of [TransparencyProperty]. Use this
  * to animate [TileOverlay.setTransparency] and [TileOverlay.getTransparency].
+ *
+ * @see [TileOverlay.removeWithFadeOut]
  */
 val OVERLAY_TRANSPARENCY: Property<TileOverlay, Float> = TransparencyProperty()
 
@@ -97,6 +99,25 @@ fun LatLng.distanceTo(other: LatLng): Float {
     )
     return results[0]
 }
+
+
+/**
+ * Fade this [TileOverlay] out, then [remove] it from the map.
+ *
+ * **NB: [TRANSPARENCY_INVISIBLE] is not the same as [ALPHA_INVISIBLE].**
+ */
+@UiThread
+fun TileOverlay.removeWithFadeOut() {
+    val animator: ObjectAnimator = ObjectAnimator.ofFloat(this, OVERLAY_TRANSPARENCY, transparency, TRANSPARENCY_INVISIBLE)
+    animator.addListener(object : AnimatorListenerAdapter() {
+        override fun onAnimationEnd(animation: Animator?) {
+            remove()
+        }
+    })
+    animator.duration = OVERLAY_FADE_DURATION
+    animator.start()
+}
+
 
 /**
  * Google's Map API throws exceptions if a marker is used when either

--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -114,7 +114,8 @@ fun TileOverlay.removeWithFadeOut() {
             remove()
         }
     })
-    animator.duration = OVERLAY_FADE_DURATION
+    // Removal should be slower than addition, to minimize chances of showing the raw background
+    animator.duration = OVERLAY_FADE_DURATION * 2
     animator.start()
 }
 

--- a/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
+++ b/map/src/main/kotlin/edu/artic/map/GoogleMapUtil.kt
@@ -118,6 +118,20 @@ fun TileOverlay.removeWithFadeOut() {
     animator.start()
 }
 
+/**
+ * Fade this [TileOverlay] in to its most opaque state ([TRANSPARENCY_VISIBLE]).
+ *
+ * **NB: [TRANSPARENCY_VISIBLE] is not the same as [ALPHA_VISIBLE].**
+ *
+ * This is _not_ called `fadeIn`, because there's already
+ * [a boolean property on TileOverlay with that name][TileOverlay.setFadeIn].
+ */
+@UiThread
+fun TileOverlay.graduallyFadeIn() {
+    val animator: ObjectAnimator = ObjectAnimator.ofFloat(this, OVERLAY_TRANSPARENCY, transparency, TRANSPARENCY_VISIBLE)
+    animator.duration = OVERLAY_FADE_DURATION
+    animator.start()
+}
 
 /**
  * Google's Map API throws exceptions if a marker is used when either

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -31,6 +31,7 @@ import edu.artic.map.helpers.toLatLng
 import edu.artic.map.rendering.GlideMapTileProvider
 import edu.artic.map.rendering.MapItemRenderer
 import edu.artic.map.rendering.MarkerMetaData
+import edu.artic.map.rendering.TRANSPARENCY_INVISIBLE
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.media.ui.getAudioServiceObservable
 import edu.artic.navigation.NavigationConstants.Companion.ARG_AMENITY_TYPE
@@ -310,9 +311,13 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                     // We want to add the new `TileOverlay` before removing the old one
                     val nextFloorPlan = map.addTileOverlay(TileOverlayOptions()
                             .zIndex(0.2f)
+                            .fadeIn(false)
+                            .transparency(TRANSPARENCY_INVISIBLE)
                             .tileProvider(GlideMapTileProvider(requireContext(), floor)))
 
-                    tileOverlay?.remove()
+                    nextFloorPlan.graduallyFadeIn()
+
+                    tileOverlay?.removeWithFadeOut()
                     tileOverlay = nextFloorPlan
                 }
                 .disposedBy(disposeBag)

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -306,10 +306,14 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 .filter { floor -> floor.number in 0..3 }
                 .withLatestFrom(viewModel.currentMap.filterValue())
                 .subscribeBy { (floor, map) ->
-                    tileOverlay?.remove()
-                    tileOverlay = map.addTileOverlay(TileOverlayOptions()
+
+                    // We want to add the new `TileOverlay` before removing the old one
+                    val nextFloorPlan = map.addTileOverlay(TileOverlayOptions()
                             .zIndex(0.2f)
                             .tileProvider(GlideMapTileProvider(requireContext(), floor)))
+
+                    tileOverlay?.remove()
+                    tileOverlay = nextFloorPlan
                 }
                 .disposedBy(disposeBag)
 

--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderers.kt
@@ -23,6 +23,14 @@ import io.reactivex.Observable
 internal const val ALPHA_INVISIBLE = 0.0f
 internal const val ALPHA_DIMMED = 0.6f
 internal const val ALPHA_VISIBLE = 1.0f
+/**
+ * The amount of transparency needed for a `TileOverlay` to be invisible.
+ */
+internal const val TRANSPARENCY_INVISIBLE = ALPHA_VISIBLE
+/**
+ * The amount of transparency needed for a `TileOverlay` to be fully opaque.
+ */
+internal const val TRANSPARENCY_VISIBLE = ALPHA_INVISIBLE
 
 
 /**


### PR DESCRIPTION
Follow-up to #153 . `TileOverlay` uses a different property than the `Marker`s: something called "`transparency`".

Note that this can't do anything about the way new tiles are added - that would require changes to the TileProvider, which is out of scope for now.