### PR TITLE
Handle missing `Member Info API` gracefully

### DIFF
--- a/info/src/main/java/edu/artic/info/AccessMemberCardViewModel.kt
+++ b/info/src/main/java/edu/artic/info/AccessMemberCardViewModel.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
  * @author Sameer Dhakal (Fuzz)
  */
 class AccessMemberCardViewModel @Inject constructor(
-        private val service: RetrofitMemberDataProvider,
+        private val service: MemberDataProvider,
         private val infoPreferencesManager: MemberInfoPreferencesManager,
         private val analyticsTracker: AnalyticsTracker
 ) : BaseViewModel() {

--- a/info/src/main/java/edu/artic/info/InfoModule.kt
+++ b/info/src/main/java/edu/artic/info/InfoModule.kt
@@ -77,20 +77,32 @@ abstract class InfoModule {
         fun provideRetrofit(@Named(ApiModule.BLOB_CLIENT_API)
                             client: OkHttpClient,
                             executor: Executor)
-                : Retrofit = constructRetrofit(
-                baseUrl = BuildConfig.MEMBER_INFO_API,
-                client = client,
-                executor = executor,
-                customConfiguration = {
-                    addConverterFactory(SimpleXmlConverterFactory.createNonStrict(
-                            Persister(AnnotationStrategy())
-                    ))
-                })
+                : Retrofit? {
+            return if (BuildConfig.MEMBER_INFO_API.contains("https")) {
+                constructRetrofit(
+                        baseUrl = BuildConfig.MEMBER_INFO_API,
+                        client = client,
+                        executor = executor,
+                        customConfiguration = {
+                            addConverterFactory(SimpleXmlConverterFactory.createNonStrict(
+                                    Persister(AnnotationStrategy())
+                            ))
+                        })
+            } else {
+                null
+            }
+        }
 
         @JvmStatic
         @Provides
         @Singleton
-        fun provideMemberInfoService(@Named(MEMBER_INFO_API) retrofit: Retrofit): MemberDataProvider = RetrofitMemberDataProvider(retrofit)
+        fun provideMemberInfoService(@Named(MEMBER_INFO_API) retrofit: Retrofit?): MemberDataProvider {
+            return if (retrofit == null) {
+                NoContentMemberDataProvider
+            } else {
+                RetrofitMemberDataProvider(retrofit)
+            }
+        }
 
         const val MEMBER_INFO_API = "MEMBER_INFO_API"
     }

--- a/info/src/main/java/edu/artic/info/InfoModule.kt
+++ b/info/src/main/java/edu/artic/info/InfoModule.kt
@@ -90,7 +90,7 @@ abstract class InfoModule {
         @JvmStatic
         @Provides
         @Singleton
-        fun provideMemberInfoService(@Named(MEMBER_INFO_API) retrofit: Retrofit) = RetrofitMemberDataProvider(retrofit)
+        fun provideMemberInfoService(@Named(MEMBER_INFO_API) retrofit: Retrofit): MemberDataProvider = RetrofitMemberDataProvider(retrofit)
 
         const val MEMBER_INFO_API = "MEMBER_INFO_API"
     }

--- a/info/src/main/java/edu/artic/info/InformationViewModel.kt
+++ b/info/src/main/java/edu/artic/info/InformationViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Named
  */
 class InformationViewModel @Inject constructor(val analyticsTracker: AnalyticsTracker,
                                                val dataObjectDao: ArticDataObjectDao,
-                                               val service: RetrofitMemberDataProvider,
+                                               val service: MemberDataProvider,
                                                @Named("VERSION") buildVersion: String)
     : NavViewViewModel<InformationViewModel.NavigationEndpoint>() {
 

--- a/info/src/main/java/edu/artic/info/MemberDataForbiddenException.kt
+++ b/info/src/main/java/edu/artic/info/MemberDataForbiddenException.kt
@@ -1,0 +1,16 @@
+package edu.artic.info
+
+/**
+ * Specialized [RuntimeException] for when [BuildConfig.MEMBER_INFO_API] does not conform
+ * to the `https://` uri scheme.
+ *
+ * Note that [BuildConfig.MEMBER_INFO_API] defaults to `"null"` (that is, a String with
+ * those four characters in that order).
+ *
+ * If this is thrown, in all likelihood the issue is a simple omission: the command-line
+ * used to build the `:info` module did not include the necessary properties. Please
+ * refer to the README for more details.
+ */
+object MemberDataForbiddenException: RuntimeException(
+        "Unfortunately, this build of the app wasn't really set up to work with membership info. Maybe in a future version?"
+)

--- a/info/src/main/java/edu/artic/info/MemberDataProvider.kt
+++ b/info/src/main/java/edu/artic/info/MemberDataProvider.kt
@@ -25,3 +25,18 @@ interface MemberDataProvider {
      */
     fun getMemberData(memberID: String, zipCode: String): Observable<SOAPMemberInfoResponse>
 }
+
+/**
+ * One of the two bundled implementations of [MemberDataProvider]. The other is
+ * [RetrofitMemberDataProvider].
+ *
+ * Returns [MemberDataForbiddenException] to everything that tries to subscribe
+ * to [getMemberData].
+ */
+object NoContentMemberDataProvider: MemberDataProvider {
+    override fun getMemberData(memberID: String, zipCode: String): Observable<SOAPMemberInfoResponse> {
+        return Observable.error {
+            MemberDataForbiddenException
+        }
+    }
+}

--- a/info/src/main/java/edu/artic/info/MemberDataProvider.kt
+++ b/info/src/main/java/edu/artic/info/MemberDataProvider.kt
@@ -6,6 +6,22 @@ import io.reactivex.Observable
  * @author Sameer Dhakal (Fuzz)
  */
 
+/**
+ * Contract between
+ * * a background service that calls an API and
+ * * the ViewModel layer ([InformationViewModel], perhaps)
+ *
+ * Implementors are encouraged to delegate their work to an instance
+ * of [MemberInfoApi].
+ */
 interface MemberDataProvider {
+    /**
+     * Retrieve information about the given member's membership. Both parameters
+     * should be non-empty.
+     *
+     * Note that this assumes that the [API][MemberInfoApi] communicates solely
+     * via `XML`; more formally, that it follows well-defined `SOAP` (Simple
+     * Object Access Protocol).
+     */
     fun getMemberData(memberID: String, zipCode: String): Observable<SOAPMemberInfoResponse>
 }


### PR DESCRIPTION
This adds a bunch of documentation to the member api and offers friendly error messages if the build was set up incorrectly. Follow-up to #135 and #147 .