### PR TITLE
Disregard unseen tour stops (AIC-435)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -187,10 +187,14 @@ class AppDataManager @Inject constructor(
                                 tourDao.clear()
                                 tours.forEach { tour ->
                                     // assign the first stop's floor to tour if tour's floor is invalid
-                                    if (tour.floorAsInt == INVALID_FLOOR && tour.tourStops.isNotEmpty()) {
-                                        tour.tourStops.first().objectId?.let { firstTourStopId ->
-                                            tour.floor = objects?.get(firstTourStopId)?.floor ?: INVALID_FLOOR
+                                    if (tour.tourStops.isNotEmpty()) {
+                                        if (tour.floorAsInt == INVALID_FLOOR) {
+                                            tour.tourStops.first().objectId?.let { firstTourStopId ->
+                                                tour.floor = objects?.get(firstTourStopId)?.floor ?: INVALID_FLOOR
+                                            }
                                         }
+                                        // Filter out stops without known objectIds (so-called 'ghost' stops)
+                                        tour.tourStops.filter { objectDao.hasObjectWithId(it.objectId) }
                                     }
 
                                 }

--- a/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
@@ -4,6 +4,7 @@ import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
+import android.support.annotation.WorkerThread
 import edu.artic.db.models.ArticObject
 import io.reactivex.Flowable
 
@@ -16,14 +17,21 @@ interface ArticObjectDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun addObjects(objects: List<ArticObject>)
 
-    //Must be flowable due to need to use this in 2 places
+    //Must be Flowable due to need to use this in 2 places
     @Query("select * from ArticObject where nid = :id")
     fun getObjectById(id: String): Flowable<ArticObject>
 
 
-    //Must be flowable due to need to use this in 2 places
+    //This one is intended for use when we don't want to filter out null objects
     @Query("select * from ArticObject where id = :id")
     fun getObjectByIdSynchronously(id: String): ArticObject?
+
+    /**
+     * Returns 1 (or more) if the object exists in the database, 0 (or less) if
+     * it's not there.
+     */
+    @Query("select count(*) from ArticObject where nid = :id limit 1")
+    fun getObjectCountWithId(id: String): Int
 
     /**
      * Return the object with an audio file given by this number.
@@ -52,4 +60,14 @@ interface ArticObjectDao {
 
     @Query("select * from ArticObject where floor = :floor")
     fun getObjectsByFloor(floor: Int): Flowable<List<ArticObject>>
+}
+
+
+/**
+ * Proxy to [ArticObjectDao.getObjectCountWithId]. Returns true if
+ * we have an object in the database under that id, false otherwise.
+ */
+@WorkerThread
+fun ArticObjectDao.hasObjectWithId(id: String?) : Boolean {
+    return id != null && getObjectCountWithId(id) > 0
 }

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsStopAdapter.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsStopAdapter.kt
@@ -20,9 +20,9 @@ class TourDetailsStopAdapter : AutoHolderRecyclerViewAdapter<TourDetailsStopCell
         item.galleryText
                 .bindToMain(tourStopGallery.text())
                 .disposedBy(item.viewDisposeBag)
-        item.stopNumber
-                .bindToMain(tourNumber.text())
-                .disposedBy(item.viewDisposeBag)
+
+        tourNumber.text = position.toString()
+
         item.imageUrl
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsViewModel.kt
@@ -155,7 +155,6 @@ class TourDetailsStopCellViewModel(tourStop: ArticTour.TourStop, objectDao: Arti
     val imageUrl: Subject<String> = BehaviorSubject.create()
     val titleText: Subject<String> = BehaviorSubject.create()
     val galleryText: Subject<String> = BehaviorSubject.create()
-    val stopNumber: Subject<String> = BehaviorSubject.createDefault("${tourStop.order + 1}.")
     val tourStop: Subject<ArticTour.TourStop> = BehaviorSubject.createDefault(tourStop)
 
     val articObjectObservable = objectDao.getObjectById(tourStop.objectId.toString())

--- a/map/src/main/kotlin/edu/artic/map/MapUtils.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapUtils.kt
@@ -41,9 +41,6 @@ fun ArticObject.getTourOrderNumberBasedOnDisplayMode(displayMode: MapDisplayMode
         /**
          * If map's display mode is Tour, get the order number of the stop.
          */
-        /**
-         * If map's display mode is Tour, get the order number of the stop.
-         */
         val index = displayMode.tour
                 .tourStops
                 .indexOfFirst { it.objectId == nid }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -197,9 +197,9 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
          * Update the floor if the selected tour stop is not in current floor.
          */
         Observables.combineLatest(tourProgressManager.selectedTour, tourProgressManager.selectedStop)
-                .filterFlatMap({ (tour, stop) -> tour.value != null },
+                .filterFlatMap({ (tour, _) -> tour.value != null },
                         { (tour, stop) -> tour.value!! to stop })
-                .flatMap { (tour, stopID) ->
+                .flatMap { (_, stopID) ->
                     articObjectDao.getObjectById(stopID).toObservable()
                 }.withLatestFrom(floor)
                 .subscribeBy { (tourStop, floor) ->

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselAdapter.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselAdapter.kt
@@ -43,9 +43,7 @@ class TourCarouselAdapter : AutoHolderRecyclerViewAdapter<TourCarousalBaseViewMo
                         }
                         .disposedBy(item.viewDisposeBag)
 
-                item.stopNumber
-                        .bindToMain(tourNumber.text())
-                        .disposedBy(item.viewDisposeBag)
+                tourNumber.text = position.toString()
 
                 item.viewPlayBackState
                         .subscribe { playBackState ->

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselViewModel.kt
@@ -7,8 +7,10 @@ import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.Playable
 import edu.artic.db.daos.ArticAudioFileDao
 import edu.artic.db.daos.ArticObjectDao
+import edu.artic.db.daos.hasObjectWithId
 import edu.artic.db.models.*
 import edu.artic.localization.LanguageSelector
+import edu.artic.map.BuildConfig
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.viewmodel.BaseViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -18,6 +20,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -95,7 +98,8 @@ class TourCarouselViewModel @Inject constructor(private val languageSelector: La
                                     .disposedBy(element.viewDisposeBag)
 
                             list.add(element)
-                        } else {
+                        } else if (objectDao.hasObjectWithId(tourStop.objectId)) {
+
                             val element = TourCarousalStopCellViewModel(tourStop, objectDao, languageSelector)
 
                             element.playerControl
@@ -111,6 +115,11 @@ class TourCarouselViewModel @Inject constructor(private val languageSelector: La
                                     .disposedBy(disposeBag)
 
                             list.add(element)
+                        } else {
+                            // Objects satisfying this condition should be filtered out at data-retrieval time (c.f. AppDataManager)
+                            if (BuildConfig.DEBUG) {
+                                Timber.i("Tour stop ${tourStop.objectId} not available at this time.")
+                            }
                         }
 
                     }
@@ -190,7 +199,6 @@ class TourCarousalStopCellViewModel(tourStop: ArticTour.TourStop, objectDao: Art
     val imageUrl: Subject<String> = BehaviorSubject.create()
     val titleText: Subject<String> = BehaviorSubject.create()
     val galleryText: Subject<String> = BehaviorSubject.create()
-    val stopNumber: Subject<String> = BehaviorSubject.createDefault("${tourStop.order + 1}.")
     val articObjectObservable = objectDao.getObjectById(tourStop.objectId.toString())
 
 


### PR DESCRIPTION
This prevents tour stops with malformed or unavailable `objectId`s from being displayed on-screen.