### PR TITLE
Prevent crash from tapping an amenity (AIC-433)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -211,13 +211,13 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.displayMode
-                .filterFlatMap({ it is MapDisplayMode.Tour }, { it as MapDisplayMode.Tour })
+                .filterTo<MapDisplayMode, MapDisplayMode.Tour>()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { (tour) -> displayFragmentInInfoContainer(TourCarouselFragment.create(tour)) }
                 .disposedBy(disposeBag)
 
         viewModel.displayMode
-                .filterFlatMap({ it is MapDisplayMode.Search<*> }, { it as MapDisplayMode.Search<*> })
+                .filterTo<MapDisplayMode, MapDisplayMode.Search<*>>()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { searchObject ->
                     when (searchObject) {
@@ -258,7 +258,10 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                     if (mode is MapDisplayMode.Search<*>) {
                         // Only need to zoom out all the way. Specific bounds are irrelevant
                         map.animateCamera(
-                                CameraUpdateFactory.zoomTo(ZOOM_MIN)
+                                CameraUpdateFactory.newLatLngZoom(
+                                        defaultMapPosition,
+                                        ZOOM_MIN
+                                )
                         )
                     } else {
                         // Make sure we can see all of the specified positions

--- a/map/src/main/kotlin/edu/artic/map/MapObjects.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapObjects.kt
@@ -6,16 +6,33 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 
-/**
- * The initial position where the [GoogleMap] starts on load of the [MapFragment]
- */
-internal fun initialMapCameraPosition(): CameraUpdate = CameraUpdateFactory.newCameraPosition(
-        CameraPosition.Builder()
-                .target(LatLng(41.879592, -87.622491))
-                .bearing(90f)
-                .tilt(45f)
-                .build())
 
+/**
+ * Center of the screen, as used by [initialMapCameraPosition].
+ *
+ * This is _NOT_ the same as the center of [museumBounds] (although it is pretty close).
+ */
+internal val defaultMapPosition = LatLng(41.879592, -87.622491)
+
+/**
+ * Camera update enforcing display of first visible content when a [MapFragment] loads.
+ *
+ * @see com.google.android.gms.maps.GoogleMap
+ */
+internal fun initialMapCameraPosition(): CameraUpdate {
+    return CameraUpdateFactory.newCameraPosition(
+            CameraPosition.Builder()
+                    .target(defaultMapPosition)
+                    .bearing(90f)
+                    .tilt(45f)
+                    .build())
+}
+
+/**
+ * Outside boundary of the area we display on the map. This is strictly larger than
+ * the museum grounds, as we allow panning and zooming a decent amount away from the
+ * buildings themselves.
+ */
 internal val museumBounds: LatLngBounds = LatLngBounds(
         // southwest
         LatLng(41.875815, -87.627528),

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -19,6 +19,7 @@ import edu.artic.location.LocationService
 import edu.artic.map.carousel.TourProgressManager
 import edu.artic.map.helpers.toLatLng
 import edu.artic.map.rendering.MarkerHolder
+import edu.artic.util.waitForASecondOfCalmIn
 import edu.artic.viewmodel.NavViewViewModel
 import edu.artic.viewmodel.Navigate
 import io.reactivex.Observable
@@ -153,9 +154,11 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
 
     init {
 
+        // It is crucial that this navigation event does not conflict with `displayMode` emissions.
         locationService.hasRequestedPermissionAlready
                 .filter { !it }
                 .map { Navigate.Forward(NavigationEndpoint.LocationPrompt) }
+                .waitForASecondOfCalmIn(displayMode)
                 .delay(1, TimeUnit.SECONDS)
                 .bindTo(navigateTo)
                 .disposedBy(disposeBag)

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -349,8 +349,12 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         val displayItem = displayMode.item
 
         Observable.just(displayItem)
-                .filterFlatMap({ it is ArticSearchArtworkObject }, { it as ArticSearchArtworkObject })
-                .map { listOf(it.toLatLng()) }
+                .map {
+                    when (it) {
+                        is ArticSearchArtworkObject -> listOf(it.toLatLng())
+                        else -> emptyList()
+                    }
+                }
                 .bindToMain(boundsOfInterestChanged)
                 .disposedBy(disposeBag)
 

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -147,7 +147,10 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
     override fun getVisibleMapFocus(displayMode: MapDisplayMode): Set<MapFocus> =
             when (displayMode) {
                 is MapDisplayMode.Tour -> MapFocus.values().toSet()
-                is MapDisplayMode.Search<*> -> MapFocus.values().toSet()
+                is MapDisplayMode.Search.ObjectSearch -> MapFocus.values().toSet()
+                // Objects NEVER show up in the AmenitiesSearch mode.
+                is MapDisplayMode.Search.AmenitiesSearch -> emptySet()
+                // 'else' includes CurrentFloor at this time.
                 else -> setOf(MapFocus.Individual)
             }
 

--- a/search/src/main/java/edu/artic/search/RetrofitSearchServiceProvider.kt
+++ b/search/src/main/java/edu/artic/search/RetrofitSearchServiceProvider.kt
@@ -6,6 +6,7 @@ import edu.artic.db.ApiBodyGenerator
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ApiSearchResult
 import edu.artic.db.models.ArticDataObject
+import edu.artic.util.mapWithDefault
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.schedulers.Schedulers

--- a/viewmodel/src/main/kotlin/edu/artic/util/ObservableExtensions.kt
+++ b/viewmodel/src/main/kotlin/edu/artic/util/ObservableExtensions.kt
@@ -1,4 +1,4 @@
-package edu.artic.search
+package edu.artic.util
 
 import com.fuzz.retrofit.rx.requireValue
 import com.jakewharton.retrofit2.adapter.rxjava2.Result


### PR DESCRIPTION
This adds three main fixes:

1. the location prompt screen is delayed until `mapDisplayMode` becomes well-defined.
2. object markers don't stick around in the amenities mode
3. when entering search mode, the camera is forcibly centered (not just zoomed out)