### PR TITLE
Display real build number in debug builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           path: app/build/test-results
       - run:
           name: Build debug APK and release APK
-          command: ./gradlew assembleDebug
+          command: ./gradlew assembleDebug -Pbuild_number=$CIRCLE_BUILD_NUM
       - store_artifacts:
           path: app/build/outputs/apk/debug
           destination: apks

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,21 @@
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+String buildMetadata
+
+if (project.hasProperty('build_number')) {
+    /**
+     * This is typically the build number produced by the CI service.
+     */
+    buildMetadata = project.getProperty('build_number')
+} else {
+    buildMetadata = 'SNAPSHOT'
+}
+
+String majorAndMinorVersion = "0.1"
+Integer patchVersionCode = 1000
+
+
 android {
     compileSdkVersion sdk
     defaultConfig {
@@ -9,8 +24,8 @@ android {
         minSdkVersion minSdk
         targetSdkVersion sdk
         multiDexEnabled true
-        versionCode 1000
-        versionName "0.1.000"
+        versionCode patchVersionCode
+        versionName "$majorAndMinorVersion.$patchVersionCode"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,13 @@ android {
         versionCode patchVersionCode
         versionName "$majorAndMinorVersion.$patchVersionCode"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        buildConfigField "String", "VERSION_NAME_FOR_DISPLAY", "VERSION_NAME"
     }
     buildTypes {
+        debug {
+            buildConfigField "String", "VERSION_NAME_FOR_DISPLAY", "\"$majorAndMinorVersion.$patchVersionCode+$buildMetadata\""
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ if (project.hasProperty('build_number')) {
     buildMetadata = 'SNAPSHOT'
 }
 
-String majorAndMinorVersion = "0.1"
+String majorAndMinorVersion = "0.6"
 Integer patchVersionCode = 1000
 
 

--- a/app/src/main/kotlin/edu/artic/AppModule.kt
+++ b/app/src/main/kotlin/edu/artic/AppModule.kt
@@ -17,9 +17,12 @@ class AppModule {
     @Provides
     fun provideApplication(): Context = ArticApp.app
 
+    /**
+     * This value is used by [edu.artic.info.InformationViewModel].
+     */
     @Provides
     @Named(VERSION)
-    fun getBuildVersion(): String = BuildConfig.VERSION_NAME
+    fun getBuildVersion(): String = BuildConfig.VERSION_NAME_FOR_DISPLAY
 
     @Provides
     @Named(DISPLAY_CONFIG)


### PR DESCRIPTION
This does not affect release builds in any significant way.

1. Determine major/minor version number and build number separately
2. In debug builds, the 'version' text on the info screen will contain more specific info