### PR TITLE
Remove `zxing-android-embedded` dependency (AIC-459)

### DIFF
--- a/access_card/build.gradle
+++ b/access_card/build.gradle
@@ -23,5 +23,4 @@ dependencies {
     implementation libs.rx_helpers
     implementation libs.rx_kotlin
     implementation libs.zxing_core
-    implementation libs.zxing_android_embedded
 }

--- a/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
+++ b/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
@@ -17,7 +17,7 @@ import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.hintRes
 import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textChanges
-import com.journeyapps.barcodescanner.BarcodeEncoder
+import edu.artic.accesscard.barcode.BarcodeEncoder
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.LoadStatus
 import edu.artic.base.utils.hideSoftKeyboard

--- a/access_card/src/main/java/edu/artic/accesscard/barcode/BarcodeEncoder.kt
+++ b/access_card/src/main/java/edu/artic/accesscard/barcode/BarcodeEncoder.kt
@@ -1,0 +1,78 @@
+package edu.artic.accesscard.barcode
+
+
+import android.graphics.Bitmap
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.WriterException
+import com.google.zxing.common.BitMatrix
+
+
+/**
+ * Helper class for encoding barcodes as a Bitmap.
+ *
+ * Adapted from QRCodeEncoder, from the zxing project:
+ * https://github.com/zxing/zxing
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+class BarcodeEncoder {
+
+    fun createBitmap(matrix: BitMatrix): Bitmap {
+        val width = matrix.width
+        val height = matrix.height
+        val pixels = IntArray(width * height)
+        for (y in 0 until height) {
+            val offset = y * width
+            for (x in 0 until width) {
+                pixels[offset + x] = if (matrix.get(x, y)) BLACK else WHITE
+            }
+        }
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+        return bitmap
+    }
+
+    @Throws(WriterException::class)
+    fun encode(contents: String, format: BarcodeFormat, width: Int, height: Int): BitMatrix {
+        try {
+            return MultiFormatWriter().encode(contents, format, width, height)
+        } catch (e: WriterException) {
+            throw e
+        } catch (e: Exception) {
+            // ZXing sometimes throws an IllegalArgumentException
+            throw WriterException(e)
+        }
+
+    }
+
+    @Throws(WriterException::class)
+    fun encode(contents: String, format: BarcodeFormat, width: Int, height: Int, hints: Map<EncodeHintType, *>): BitMatrix {
+        try {
+            return MultiFormatWriter().encode(contents, format, width, height, hints)
+        } catch (e: WriterException) {
+            throw e
+        } catch (e: Exception) {
+            throw WriterException(e)
+        }
+
+    }
+
+    @Throws(WriterException::class)
+    fun encodeBitmap(contents: String, format: BarcodeFormat, width: Int, height: Int): Bitmap {
+        return createBitmap(encode(contents, format, width, height))
+    }
+
+    @Throws(WriterException::class)
+    fun encodeBitmap(contents: String, format: BarcodeFormat, width: Int, height: Int, hints: Map<EncodeHintType, *>): Bitmap {
+        return createBitmap(encode(contents, format, width, height, hints))
+    }
+
+    companion object {
+        private val WHITE = -0x1
+        private val BLACK = -0x1000000
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,7 @@ buildscript {
                 exo_player_media_session: "com.google.android.exoplayer:extension-mediasession:$exo_player_version",
                 view_indicator          : "com.github.fuzz-productions:CutoutViewIndicator:v0.8.2",
                 custom_tabs             : "com.android.support:customtabs:${support_version}",
-                zxing_core              : 'com.google.zxing:core:3.3.0',
-                zxing_android_embedded  : 'com.journeyapps:zxing-android-embedded:3.6.0'
+                zxing_core              : 'com.google.zxing:core:3.3.0'
 
         ]
 


### PR DESCRIPTION
Updates:
- Copies the required `BarcodeEncoder` and removes `zxing-android-embedded` dependency