### PR TITLE
Show 'Leave Tour?' prompt every time we get a request to show it (AIC-519)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -418,7 +418,6 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
         viewModel
                 .switchTourRequest
-                .distinctUntilChanged()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { (_, _) ->
                     displayLeaveTourConfirmation()


### PR DESCRIPTION
The `distinctUntilChanged` operator used in `switchTourRequest` stream was ignoring the events when the active tour and requested tour were same. 

FIxes the issue for following scenario.
User requests a new tour (say T1) while tour T in progress and decide to stay with T. 
Then again request same tour T1, app was not displaying the leave tour dialog.
