### PR TITLE
Audio details: use app language for dropdowns (AIC-382)

### DIFF
--- a/localization/src/main/kotlin/edu/artic/localization/SpecifiesLanguage.kt
+++ b/localization/src/main/kotlin/edu/artic/localization/SpecifiesLanguage.kt
@@ -21,14 +21,30 @@ interface SpecifiesLanguage {
         return Locale.forLanguageTag(underlyingLanguage())
     }
 
-    fun userFriendlyLanguage(forThisView: Context): CharSequence {
-        val current = forThisView.resources.configuration
+    /**
+     * Retrieve the name of [underlyingLocale]'s language in that language.
+     */
+    private fun nameOfLanguageInThatLanguage(ctx: Context): CharSequence {
+        val current = ctx.resources.configuration
 
-        return forThisView.createConfigurationContext(
+        return ctx.createConfigurationContext(
                 Configuration(current).apply {
                     // Locale retrieval on pre-Nougat is somewhat lacking
                     setLocale(Locale.forLanguageTag(underlyingLocale().language))
                 }
         ).getText(R.string.name_of_this_language)
+    }
+
+    /**
+     * Retrieve the name of [underlyingLocale]'s language under the given Context's
+     * config.
+     */
+    fun userFriendlyLanguage(ctx: Context): CharSequence {
+        return when(underlyingLocale().language) {
+            Locale.ENGLISH.language -> ctx.getText(R.string.english)
+            SPANISH.language -> ctx.getText(R.string.spanish)
+            Locale.CHINESE.language -> ctx.getText(R.string.chinese)
+            else -> underlyingLocale().displayLanguage
+        }
     }
 }

--- a/localization/src/main/res/values-en/strings.xml
+++ b/localization/src/main/res/values-en/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="english">English</string>
+    <string name="spanish">Spanish</string>
+    <string name="chinese">Chinese</string>
+</resources>

--- a/localization/src/main/res/values-es/strings.xml
+++ b/localization/src/main/res/values-es/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="english">Inglés</string>
+    <string name="spanish">Español</string>
+    <string name="chinese">Chino</string>
+</resources>

--- a/localization/src/main/res/values-zh/strings.xml
+++ b/localization/src/main/res/values-zh/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="english">英文</string>
+    <string name="spanish">西班牙语</string>
+    <string name="chinese">中文</string>
+</resources>

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="english">English</string>
+    <string name="spanish">Español</string>
+    <string name="chinese">中文</string>
 
     <string name="english_in_that_language" translatable="false">English</string>
     <string name="spanish_in_that_language" translatable="false">Español</string>

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="spanish">Español</string>
     <string name="chinese">中文</string>
 
-    <string name="english_in_that_language" translatable="false">English</string>
-    <string name="spanish_in_that_language" translatable="false">Español</string>
-    <string name="chinese_in_that_language" translatable="false">中文</string>
+    <string name="english_in_english" translatable="false">English</string>
+    <string name="spanish_in_spanish" translatable="false">Español</string>
+    <string name="chinese_in_chinese" translatable="false">中文</string>
 </resources>

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="english_in_that_language" translatable="false">English</string>
+    <string name="spanish_in_that_language" translatable="false">Español</string>
+    <string name="chinese_in_that_language" translatable="false">中文</string>
+</resources>

--- a/localization_ui/src/main/res/layout/fragment_language_settings.xml
+++ b/localization_ui/src/main/res/layout/fragment_language_settings.xml
@@ -114,7 +114,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/english"
+                    android:text="@string/english_in_that_language"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     tools:checked="true" />
 
@@ -128,7 +128,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/spanish"
+                    android:text="@string/spanish_in_that_language"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -144,7 +144,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/chinese"
+                    android:text="@string/chinese_in_that_language"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/localization_ui/src/main/res/layout/fragment_language_settings.xml
+++ b/localization_ui/src/main/res/layout/fragment_language_settings.xml
@@ -114,7 +114,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/english_in_that_language"
+                    android:text="@string/english_in_english"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     tools:checked="true" />
 
@@ -128,7 +128,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/spanish_in_that_language"
+                    android:text="@string/spanish_in_spanish"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -144,7 +144,7 @@
                     android:layout_marginEnd="@dimen/marginDouble"
                     android:background="?attr/languageSettingsButtonBackground"
                     android:button="@null"
-                    android:text="@string/chinese_in_that_language"
+                    android:text="@string/chinese_in_chinese"
                     android:textColor="?attr/languageSettingsButtonTextColor"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/localization_ui/src/main/res/values/strings.xml
+++ b/localization_ui/src/main/res/values/strings.xml
@@ -2,8 +2,5 @@
     <string name="languageSettings">Language Settings</string>
     <string name="languageSettingsBody">Some content may not be available in your selected language.</string>
     <string name="chooseYourLanguage">Please Choose Your Preferred Language</string>
-    <string name="english" translatable="false">English</string>
-    <string name="spanish" translatable="false">Español</string>
-    <string name="chinese" translatable="false">中文</string>
 
 </resources>


### PR DESCRIPTION
This covers the change in appearance of the dropdown/spinner view on the audio details screen. Previously, it showed the languages as spelled in that language (`English`, `Español`, `中文`), while now it'll show them all in the language of the application (`English`, `Spanish`, `Chinese`).