### PR TITLE
Update some minor text and fix a crash (AIC-524)

### DIFF
--- a/info/src/main/java/edu/artic/info/InformationFragment.kt
+++ b/info/src/main/java/edu/artic/info/InformationFragment.kt
@@ -63,13 +63,14 @@ class InformationFragment : BaseViewModelFragment<InformationViewModel>() {
 
 
         viewModel.buildVersion
-                .subscribe { versionName ->
+                .subscribeBy { versionName ->
                     versionInfo.text = getString(R.string.versionInfo, versionName)
                 }
                 .disposedBy(disposeBag)
 
 
         viewModel.generalInfo
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy {
                     appBarLayout.setSubtitleText(it.infoSubtitle)
                     requestTitleUpdate(it.infoTitle)

--- a/location_ui/src/main/res/values-en/strings.xml
+++ b/location_ui/src/main/res/values-en/strings.xml
@@ -6,7 +6,7 @@
     <string name="locationSettingsLocationDenied">Location Disabled</string>
     <string name="locationSettingsLocationAllowed">Location Enabled</string>
     <string name="locationPromptNotNow">Not Right Now</string>
-    <string name="locationPromptOk">OK, Use My Location</string>
+    <string name="locationPromptOk">Ok</string>
     <string name="locationSettingsLocationServiceOff">Location Service Off</string>
-    <string name="locationSettingsLocationNeverAsked">Location Settings</string>
+    <string name="locationSettingsLocationNeverAsked">@string/location_title</string>
 </resources>

--- a/location_ui/src/main/res/values-es/strings.xml
+++ b/location_ui/src/main/res/values-es/strings.xml
@@ -6,7 +6,7 @@
     <string name="locationSettingsLocationDenied">Ubicación deshabilitada</string>
     <string name="locationSettingsLocationAllowed">Ubicación habilitada</string>
     <string name="locationPromptNotNow">No Ahora</string>
-    <string name="locationSettingsLocationNeverAsked">Ajustes de ubicación</string>
-    <string name="locationPromptOk">OK, usa mi ubicación</string>
+    <string name="locationSettingsLocationNeverAsked">@string/location_title</string>
+    <string name="locationPromptOk">Ok</string>
     <string name="locationSettingsLocationServiceOff">Servicio de ubicación desactivado</string>
 </resources>

--- a/location_ui/src/main/res/values-zh/strings.xml
+++ b/location_ui/src/main/res/values-zh/strings.xml
@@ -6,7 +6,7 @@
     <string name="locationSettingsLocationDenied">禁用定位服务</string>
     <string name="locationSettingsLocationAllowed">启用定位服务</string>
     <string name="locationPromptNotNow">不是现在</string>
-    <string name="locationSettingsLocationNeverAsked">位置设置</string>
-    <string name="locationPromptOk">好的，使用我的位置</string>
+    <string name="locationSettingsLocationNeverAsked">@string/location_title</string>
+    <string name="locationPromptOk">确定</string>
     <string name="locationSettingsLocationServiceOff">位置服務關閉</string>
 </resources>

--- a/location_ui/src/main/res/values/strings.xml
+++ b/location_ui/src/main/res/values/strings.xml
@@ -8,5 +8,9 @@
     <string name="locationSettingsLocationAllowed">Location Enabled</string>
     <string name="locationSettingsLocationDenied">Location Disabled</string>
     <string name="locationPromptNotNow">Not Right Now</string>
-    <string name="locationPromptOk">OK, Use My Location</string>
+
+    <!-- NB: This is a fallback. We do not generally use the standard 'ok' for this string. -->
+    <!--suppress AndroidDomInspection -->
+    <string name="locationPromptOk">@android:string/ok</string>
+
 </resources>

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -31,15 +31,33 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
 
     private var requestedTitle: String? = null
 
+    /**
+     * This method can be used to manually update
+     *
+     * * [requestedTitle] (which can be retrieved later with [getToolbarTitle])
+     * * The [activity's title][BaseActivity.setTitle]
+     * and
+     * * (If present) the [collapsing toolbar][collapsingToolbar]'s title
+     *
+     * C.f. [updateToolbar]
+     */
     fun requestTitleUpdate(proposedTitle: String) {
-        this.requestedTitle = proposedTitle
-        baseActivity.title = proposedTitle
+        baseActivity.runOnUiThread {
+            this.requestedTitle = proposedTitle
+            /**
+             * This assignment to BaseActivity.title
+             *
+             * 1. updates the title in regular [Toolbar]s
+             * 2. **does not** update the title in [CollapsingToolbarLayout]s
+             */
+            baseActivity.title = proposedTitle
 
-        /**
-         * BaseActivity.title does not update the title for the fragments with collapsing toolbar title.
-         */
-        updateToolbar(requireView())
-        collapsingToolbar?.title = proposedTitle
+            /**
+             * Ensure [toolbar] and [collapsingToolbar] have had a chance to be bound
+             */
+            updateToolbar(requireView())
+            collapsingToolbar?.title = proposedTitle
+        }
     }
 
     private fun getToolbarTitle(): String {

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -23,6 +23,7 @@ import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.fragment_welcome.*
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
@@ -100,7 +101,7 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.currentCardHolder
-                .subscribe { cardHolder ->
+                .subscribeBy { cardHolder ->
                     val firstName = cardHolder.split(" ").first()
                     val title = resources.getString(R.string.welcomeUser, firstName)
                     requestTitleUpdate(title)


### PR DESCRIPTION
Switching languages while the map is in the background can cause a crash, since the `::requestTitleUpdate` function wasn't forced to the main thread.

Also, some minor textual updates to the location settings screen and to the location request prompt.