### PR TITLE
Show translatable tour descriptions on home (AIC-527)

### DIFF
--- a/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
@@ -38,6 +38,24 @@ fun String.asUrlViewIntent(action: String = Intent.ACTION_VIEW): Intent {
 }
 
 /**
+ * If this
+ * * is not null and
+ * * is not the empty string `""` and
+ * * doesn't just consist of spaces
+ *
+ * then this function just returns the String it was called on.
+ *
+ * Otherwise, we will return [alternate].
+ */
+fun String?.orIfNullOrBlank(alternate: String?): String? {
+    return if (this.isNullOrBlank()) {
+        alternate
+    } else {
+        this
+    }
+}
+
+/**
  * Decodes html encoded strings preserving new line chars.
  */
 fun String.filterHtmlEncodedText(): String {

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
@@ -162,7 +162,7 @@ class WelcomeViewModel @Inject constructor(private val welcomePreferencesManager
 }
 
 /**
- * ViewModel responsible for building the tour summary list.
+ * ViewModel responsible for building each item in the tour summary list.
  */
 class WelcomeTourCellViewModel(val tour: ArticTour) : CellViewModel(null) {
 
@@ -174,7 +174,7 @@ class WelcomeTourCellViewModel(val tour: ArticTour) : CellViewModel(null) {
 }
 
 /**
- * ViewModel responsible for building the `On View` list (i.e. list of exhibition).
+ * ViewModel responsible for building each item in the `On View` list (i.e. the list of exhibitions).
  */
 class WelcomeExhibitionCellViewModel(
         adapterDisposeBag: DisposeBag,

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
@@ -6,6 +6,7 @@ import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
 import edu.artic.base.utils.DateTimeHelper.Purpose.*
+import edu.artic.base.utils.orIfNullOrBlank
 import edu.artic.db.daos.ArticEventDao
 import edu.artic.db.daos.ArticExhibitionDao
 import edu.artic.db.daos.ArticTourDao
@@ -176,10 +177,10 @@ class WelcomeTourCellViewModel(
      */
     private val tourTranslation: Subject<ArticTour.Translation> = BehaviorSubject.create()
 
-    val tourTitle: Subject<String> = BehaviorSubject.createDefault(tour.title)
-    val tourDescription: Subject<String> = BehaviorSubject.createDefault(tour.description)
+    val tourTitle: Subject<String> = BehaviorSubject.create()
+    val tourDescription: Subject<String> = BehaviorSubject.create()
     val tourStops: Subject<String> = BehaviorSubject.createDefault(tour.tourStops.count().toString())
-    val tourDuration: Subject<String> = BehaviorSubject.createDefault(tour.tourDuration)
+    val tourDuration: Subject<String> = BehaviorSubject.create()
     val tourImageUrl: Subject<String> = BehaviorSubject.createDefault(tour.standardImageUrl)
 
     init {
@@ -191,6 +192,26 @@ class WelcomeTourCellViewModel(
                 .bindTo(tourTranslation)
                 .disposedBy(disposeBag)
 
+        tourTranslation
+                .map {
+                    it.description.orIfNullOrBlank(tour.description).orEmpty()
+                }
+                .bindToMain(tourDescription)
+                .disposedBy(disposeBag)
+
+        tourTranslation
+                .map {
+                    it.title.orIfNullOrBlank(tour.title).orEmpty()
+                }
+                .bindToMain(tourTitle)
+                .disposedBy(disposeBag)
+
+        tourTranslation
+                .map {
+                    it.tour_duration.orIfNullOrBlank(tour.tourDuration).orEmpty()
+                }
+                .bindToMain(tourDuration)
+                .disposedBy(disposeBag)
     }
 }
 


### PR DESCRIPTION
This ensures that the initial list of tours prefers translations of said tours into the app-wide language, if that language is not English (when it is English, the behavior is unchanged). Note that Exhibitions (`On View`) and Events do not come with translations at this time.