### PR TITLE
Include link to website when no search results are found (AIC-515)

### DIFF
--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
@@ -3,6 +3,7 @@ package edu.artic.search
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.daos.ArticSearchObjectDao
 import io.reactivex.rxkotlin.Observables
@@ -17,8 +18,9 @@ import javax.inject.Inject
 class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao: ArticSearchObjectDao,
                                                             objectDao: ArticObjectDao,
                                                             analyticsTracker: AnalyticsTracker,
-                                                            searchManager: SearchResultsManager
-) : SearchBaseViewModel(analyticsTracker, searchManager) {
+                                                            searchManager: SearchResultsManager,
+                                                            dataObjectDao: ArticDataObjectDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao) {
 
     private val suggestedKeywords: Subject<List<SearchTextCellViewModel>> = BehaviorSubject.create()
     private val suggestedArtworks: Subject<List<SearchCircularCellViewModel>> = BehaviorSubject.create()

--- a/search/src/main/java/edu/artic/search/SearchArtworkViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchArtworkViewModel.kt
@@ -3,12 +3,14 @@ package edu.artic.search
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.db.daos.ArticDataObjectDao
 import javax.inject.Inject
 
 class SearchArtworkViewModel @Inject constructor(
         searchManager: SearchResultsManager,
-        analyticsTracker: AnalyticsTracker
-) : SearchBaseViewModel(analyticsTracker, searchManager) {
+        analyticsTracker: AnalyticsTracker,
+        dataObjectDao: ArticDataObjectDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao) {
 
     sealed class NavigationEndpoint
 

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -20,8 +20,11 @@ import kotlinx.android.synthetic.main.fragment_search_results_sub.*
 import java.util.concurrent.TimeUnit
 import android.app.Activity
 import android.content.Context
+import android.net.Uri
 import android.view.inputmethod.InputMethodManager
+import edu.artic.base.utils.customTab.CustomTabManager
 import edu.artic.base.utils.hideSoftKeyboard
+import javax.inject.Inject
 
 
 abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewModelFragment<TViewModel>() {
@@ -30,6 +33,9 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
     override val screenCategory: ScreenCategoryName? = null
 
     override val overrideStatusBarColor: Boolean = false
+
+    @Inject
+    lateinit var customTabManager: CustomTabManager
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -132,8 +138,9 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
                         SearchBaseViewModel.NavigationEndpoint.HideKeyboard -> {
                             requireActivity().hideSoftKeyboard()
                         }
-                        SearchBaseViewModel.NavigationEndpoint.Web -> {
-
+                        is SearchBaseViewModel.NavigationEndpoint.Web -> {
+                            val url = endpoint.url
+                            customTabManager.openUrlOnChromeCustomTab(requireContext(), Uri.parse(url))
                         }
                     }
                 }

--- a/search/src/main/java/edu/artic/search/SearchExhibitionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchExhibitionsViewModel.kt
@@ -3,12 +3,14 @@ package edu.artic.search
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.db.daos.ArticDataObjectDao
 import javax.inject.Inject
 
 class SearchExhibitionsViewModel @Inject constructor(
         searchManager: SearchResultsManager,
-        analyticsTracker: AnalyticsTracker
-) : SearchBaseViewModel(analyticsTracker, searchManager)  {
+        analyticsTracker: AnalyticsTracker,
+        dataObjectDao: ArticDataObjectDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao)  {
 
     sealed class NavigationEndpoint
 

--- a/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
@@ -5,6 +5,7 @@ import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
+import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.daos.ArticSearchObjectDao
 import edu.artic.db.models.ArticExhibition
@@ -19,8 +20,9 @@ import javax.inject.Inject
 class SearchSuggestedViewModel @Inject constructor(private val manager: SearchResultsManager,
                                                    private val searchSuggestionsDao: ArticSearchObjectDao,
                                                    private val objectDao: ArticObjectDao,
-                                                   analyticsTracker: AnalyticsTracker)
-    : SearchBaseViewModel(analyticsTracker, manager) {
+                                                   analyticsTracker: AnalyticsTracker,
+                                                   dataObjectDao: ArticDataObjectDao)
+    : SearchBaseViewModel(analyticsTracker, manager, dataObjectDao) {
 
     private val dynamicCells: Subject<List<SearchBaseCellViewModel>> = BehaviorSubject.create()
     private val suggestedArtworks: Subject<List<SearchCircularCellViewModel>> = BehaviorSubject.create()

--- a/search/src/main/java/edu/artic/search/SearchToursViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchToursViewModel.kt
@@ -3,12 +3,14 @@ package edu.artic.search
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.db.daos.ArticDataObjectDao
 import javax.inject.Inject
 
 class SearchToursViewModel @Inject constructor(
         searchManager: SearchResultsManager,
-        analyticsTracker: AnalyticsTracker
-) : SearchBaseViewModel(analyticsTracker, searchManager)  {
+        analyticsTracker: AnalyticsTracker,
+        dataObjectDao: ArticDataObjectDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao)  {
 
     sealed class NavigationEndpoint
 

--- a/search/src/main/res/layout/layout_cell_empty.xml
+++ b/search/src/main/res/layout/layout_cell_empty.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="15dp"
-    android:paddingBottom="20dp">
+    android:paddingBottom="20dp"
+    tools:background="@color/darkGrey">
 
     <TextView
         android:id="@+id/topText"
@@ -22,8 +24,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/couldnt_find_bottom_text"
+        android:textSize="@dimen/textSmall"
         app:layout_constrainedHeight="true"
+        android:lineSpacingExtra="3dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="@dimen/marginStandard"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/topText" />

--- a/search/src/main/res/values-es/strings.xml
+++ b/search/src/main/res/values-es/strings.xml
@@ -3,6 +3,6 @@
     <string name="gallery">Galería %s</string>
     <string name="artworks">Obras de arte</string>
     <string name="couldnt_find_top_text">Lo sentimos, no encontramos resultados</string>
-    <string name="couldnt_find_bottom_text">Para obtener ayuda, visite al representante del museo más cercano o [visite nuestro sitio web].</string>
+    <string name="couldnt_find_bottom_text">Para obtener ayuda, visite al representante del museo más cercano o <u>visite nuestro sitio web.</u></string>
     <string name="exhibitions">Exhibiciones</string>
 </resources>

--- a/search/src/main/res/values-zh/strings.xml
+++ b/search/src/main/res/values-zh/strings.xml
@@ -3,6 +3,6 @@
     <string name="gallery">画廊 %s</string>
     <string name="artworks">艺术作品</string>
     <string name="couldnt_find_top_text">抱歉，我们无法找到。</string>
-    <string name="couldnt_find_bottom_text">如需帮助，请咨询最近的博物馆人员或[访问我们的网站]。</string>
+    <string name="couldnt_find_bottom_text">如需帮助，请咨询最近的博物馆人员或<u>访问我们的网站</u>。</string>
     <string name="exhibitions">展览</string>
 </resources>

--- a/search/src/main/res/values/strings.xml
+++ b/search/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="couldnt_find_top_text">Sorry, we couldn’t find that.</string>
-    <string name="couldnt_find_bottom_text">For help, visit the nearest museum representitve or visit our website</string>
+    <string name="couldnt_find_bottom_text">For help, visit the nearest museum representative or <u>visit our website</u></string>
     <string name="gallery">Gallery %s</string>
     <string name="artworks">Artworks</string>
     <string name="exhibitions">Exhibitions</string>


### PR DESCRIPTION
* Adds correct spacing between empty result prompt and title (AIC-515)
* underlines `visit our website` string
* Loads website when empty search result prompt is clicked. (AIC-534)