### PR TITLE
Improve HTML parsing on Event Details screen (AIC-414)

### DIFF
--- a/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
@@ -41,12 +41,12 @@ fun String.trimDownBlankLines(): String {
  * parameter. See [Html.fromHtml] and overloads thereof for more details.
  */
 @SuppressLint("InlinedApi")
-fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_LEGACY): Spanned {
+fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_LEGACY): CharSequence {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         Html.fromHtml(this, flags)
     } else {
         Html.fromHtml(this)
-    }
+    }.trim()
 }
 
 fun String.asUrlViewIntent(action: String = Intent.ACTION_VIEW): Intent {

--- a/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
@@ -1,9 +1,11 @@
 package edu.artic.base.utils
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.text.Html
+import android.text.Spanned
 
 /**
  *@author Sameer Dhakal (Fuzz)
@@ -20,9 +22,16 @@ fun String.asDeepLinkIntent(action: String = Intent.ACTION_VIEW, schema: String 
     return Intent(action, Uri.parse("$schema://${this}"))
 }
 
-fun String.fromHtml(): CharSequence {
+/**
+ * Convert this (probably HTML-style) text into the [Spanned] equivalent.
+ *
+ * On Android N and higher you can override the parse mode with the [flags]
+ * parameter. See [Html.fromHtml] and overloads thereof for more details.
+ */
+@SuppressLint("InlinedApi")
+fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_LEGACY): Spanned {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        Html.fromHtml(this, Html.FROM_HTML_MODE_LEGACY)
+        Html.fromHtml(this, flags)
     } else {
         Html.fromHtml(this)
     }

--- a/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/StringExtensions.kt
@@ -22,6 +22,18 @@ fun String.asDeepLinkIntent(action: String = Intent.ACTION_VIEW, schema: String 
     return Intent(action, Uri.parse("$schema://${this}"))
 }
 
+
+/**
+ * Sometimes HTML content comes in with 3 or more blank lines in a row.
+ *
+ * This detects and replaces such occurrences with a single html `br` tag.
+ */
+fun String.trimDownBlankLines(): String {
+    return replace("\n\n", "\n")
+            .replace("\n", "<br/>")
+            .replace("<br/><strong><br/></strong>", "<br/>")
+}
+
 /**
  * Convert this (probably HTML-style) text into the [Spanned] equivalent.
  *

--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -3,6 +3,7 @@ package edu.artic.events
 import android.os.Bundle
 import android.support.v4.math.MathUtils
 import android.support.v4.widget.NestedScrollView
+import android.text.Html
 import android.view.View
 import android.widget.ImageView
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
@@ -15,6 +16,7 @@ import com.jakewharton.rxbinding2.widget.text
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.asUrlViewIntent
 import edu.artic.base.utils.fromHtml
+import edu.artic.base.utils.trimDownBlankLines
 import edu.artic.db.models.ArticEvent
 import edu.artic.details.R
 import edu.artic.image.GlideApp
@@ -98,7 +100,7 @@ class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
 
         viewModel.description
                 .map {
-                    it.fromHtml()
+                    it.trimDownBlankLines().fromHtml(Html.FROM_HTML_MODE_COMPACT)
                 }
                 .bindToMain(description.text())
                 .disposedBy(disposeBag)

--- a/details/src/main/res/layout/fragment_event_details.xml
+++ b/details/src/main/res/layout/fragment_event_details.xml
@@ -99,7 +99,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/metaData"
-                tools:text="Buy Tickets"
+                tools:text="@string/buyTickets"
                 tools:visibility="visible"/>
 
             <TextView
@@ -110,6 +110,8 @@
                 android:layout_marginLeft="@dimen/marginDouble"
                 android:layout_marginRight="@dimen/marginDouble"
                 android:layout_marginTop="@dimen/marginDouble"
+                android:includeFontPadding="false"
+                android:lineSpacingExtra="-8sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/registerToday"


### PR DESCRIPTION
Minor fix to the text spacing on event details screen too.

The HTML change mostly just detects newlines more-or-less in line with the swift source code.