### PR TITLE
Update to SDK 28, fix dependencies and use lineheight

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".ArticApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">artic.edu</domain>
+    </domain-config>
+</network-security-config>

--- a/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
@@ -23,19 +23,12 @@ import edu.artic.base.R
 fun BottomNavigationView.disableShiftMode(colorList: Int = 0) {
     val menuView = getChildAt(0) as BottomNavigationMenuView
 
-    menuView.javaClass.getDeclaredField("mShiftingMode").apply {
-        isAccessible = true
-        setBoolean(menuView, false)
-        isAccessible = false
-    }
-
     // While we're adjusting the other properties, we can normalize the font in use too.
     val type: Typeface? = ResourcesCompat.getFont(context, R.font.ideal_sans_semibold)
 
     @SuppressLint("RestrictedApi")
     for (i in 0 until menuView.childCount) {
         (menuView.getChildAt(i) as BottomNavigationItemView).apply {
-            setShiftingMode(false)
             setChecked(false)
             if (type != null) {
                 overrideLabelFont(type)

--- a/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
@@ -34,6 +34,7 @@ fun BottomNavigationView.disableShiftMode(colorList: Int = 0) {
                 overrideLabelFont(type)
             }
             if (colorList > 0) {
+                setIconTintList(ContextCompat.getColorStateList(this.context, colorList))
                 setTextColor(ContextCompat.getColorStateList(this.context, colorList))
             }
         }

--- a/base/src/main/res/values/dimens.xml
+++ b/base/src/main/res/values/dimens.xml
@@ -40,6 +40,9 @@
     <dimen name="textFifteen">15sp</dimen>
     <dimen name="textSixteen">16sp</dimen>
 
+    <dimen name="lineHeightTextSixteen">20sp</dimen>
+    <dimen name="lineHeightTextMedium">25sp</dimen>
+
     <dimen name="bottom_audio_player_height">40dp</dimen>
     <dimen name="bottomAudioControlIconSize">32dp</dimen>
     <dimen name="audioPlayerControllerSize">32dp</dimen>

--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -136,12 +136,16 @@
         <item name="android:textSize">@dimen/textMedium</item>
         <item name="android:textColor">@color/greyText</item>
         <item name="android:fontFamily">@font/amiri_italic</item>
+        <item name="lineHeight">@dimen/lineHeightTextMedium</item>
+        <item name="android:includeFontPadding">false</item>
     </style>
 
     <style name="CardBodySerifGray">
         <item name="android:textSize">@dimen/textMedium</item>
         <item name="android:textColor">@color/greyText</item>
         <item name="android:fontFamily">@font/amiri_regular</item>
+        <item name="lineHeight">@dimen/lineHeightTextMedium</item>
+        <item name="android:includeFontPadding">false</item>
     </style>
 
     <style name="DetailsDescription" parent="CardBodySerifGray">
@@ -271,6 +275,7 @@
         <item name="android:lineSpacingExtra">4sp</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">@dimen/textSixteen</item>
+        <item name="lineHeight">@dimen/lineHeightTextSixteen</item>
     </style>
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         moshi_version = '1.6.0'
         room_version = '1.1.1'
         glide_version = '4.4.0'
-        firebase_version = '16.0.1'
+        firebase_version = '16.0.4'
         crashlytics_version = '2.9.5'
         exo_player_version = '2.9.0'
 
@@ -65,7 +65,7 @@ buildscript {
                 exo_player_dash         : "com.google.android.exoplayer:exoplayer-dash:$exo_player_version",
                 exo_player_ui           : "com.google.android.exoplayer:exoplayer-ui:$exo_player_version",
                 exo_player_media_session: "com.google.android.exoplayer:extension-mediasession:$exo_player_version",
-                media_compat: "com.android.support:support-media-compat:${support_version}",
+                media_compat            : "com.android.support:support-media-compat:${support_version}",
                 view_indicator          : "com.github.fuzz-productions:CutoutViewIndicator:v0.8.2",
                 custom_tabs             : "com.android.support:customtabs:${support_version}",
                 zxing_core              : 'com.google.zxing:core:3.3.0'
@@ -87,6 +87,15 @@ buildscript {
 }
 
 subprojects {
+
+    configurations.all {
+        resolutionStrategy {
+            force   "com.android.support:support-v4:${support_version}",
+                    "com.android.support:support-media-compat:${support_version}",
+                    "com.android.support:design:${support_version}"
+        }
+    }
+
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ buildscript {
                 exo_player_dash         : "com.google.android.exoplayer:exoplayer-dash:$exo_player_version",
                 exo_player_ui           : "com.google.android.exoplayer:exoplayer-ui:$exo_player_version",
                 exo_player_media_session: "com.google.android.exoplayer:extension-mediasession:$exo_player_version",
+                media_compat: "com.android.support:support-media-compat:${support_version}",
                 view_indicator          : "com.github.fuzz-productions:CutoutViewIndicator:v0.8.2",
                 custom_tabs             : "com.android.support:customtabs:${support_version}",
                 zxing_core              : 'com.google.zxing:core:3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@
 
 buildscript {
     ext {
-        sdk = 27
+        sdk = 28
         minSdk = 21
         kotlin_version = '1.2.71'
         latest_helper = '72626c5db8'
         dagger_version = '2.15'
-        support_version = '27.1.1'
+        support_version = '28.0.0'
         arch_version = '1.1.0'
         navigation_version = '1.0.0-alpha05'
         paging_version = '1.0.0-beta1'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         glide_version = '4.4.0'
         firebase_version = '16.0.1'
         crashlytics_version = '2.9.5'
-        exo_player_version = '2.8.2'
+        exo_player_version = '2.9.0'
 
         libs = [
                 kotlin                  : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
@@ -125,8 +125,8 @@ subprojects {
             targetSdkVersion sdk
         }
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
         }
         sourceSets {
             main.java.srcDirs += 'src/main/kotlin'

--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,7 @@ subprojects {
 
     configurations.all {
         resolutionStrategy {
-            force   "com.android.support:support-v4:${support_version}",
-                    "com.android.support:support-media-compat:${support_version}",
-                    "com.android.support:design:${support_version}"
+            force   libs.v4_support, libs.design_support, libs.media_compat
         }
     }
 

--- a/details/src/main/res/layout/fragment_event_details.xml
+++ b/details/src/main/res/layout/fragment_event_details.xml
@@ -106,8 +106,6 @@
                 android:layout_marginLeft="@dimen/marginDouble"
                 android:layout_marginRight="@dimen/marginDouble"
                 android:layout_marginTop="@dimen/marginDouble"
-                android:includeFontPadding="false"
-                android:lineSpacingMultiplier=".62"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/registerToday"

--- a/events/src/main/kotlin/edu/artic/events/recyclerview/AllEventsItemDecoration.kt
+++ b/events/src/main/kotlin/edu/artic/events/recyclerview/AllEventsItemDecoration.kt
@@ -18,7 +18,7 @@ class AllEventsItemDecoration(
     private val verticalSpacing: Int = context.resources.getDimensionPixelOffset(R.dimen.all_tour_cell_spacing_vertical)
     private val headerVerticalSpacing: Int = context.resources.getDimensionPixelOffset(R.dimen.all_tour_cell_spacing_vertical_header)
 
-    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State?) {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         // item position
         val position = parent.getChildAdapterPosition(view)
         adapter.getItemOrNull(position)?.let {

--- a/exhibitions/src/main/kotlin/edu/artic/exhibitions/recyclerview/AllToursItemDecoration.kt
+++ b/exhibitions/src/main/kotlin/edu/artic/exhibitions/recyclerview/AllToursItemDecoration.kt
@@ -14,7 +14,7 @@ class AllExhibitionsItemDecoration(
     private val horizontalSpacing: Int = context.resources.getDimensionPixelSize(R.dimen.all_exhibitions_cell_spacing_horizontal)
     private val verticalSpacing: Int = context.resources.getDimensionPixelSize(R.dimen.all_exhibitions_cell_spacing_vertical)
 
-    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State?) {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         var position = parent.getChildAdapterPosition(view) // item position
         position -= 1
         val column = (position) % spanCount // item column

--- a/exhibitions/src/main/res/layout/cell_all_exhibitions_layout.xml
+++ b/exhibitions/src/main/res/layout/cell_all_exhibitions_layout.xml
@@ -39,7 +39,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/marginStandard"
         android:ellipsize="end"
-        android:includeFontPadding="false"
         android:lines="1"
         android:textColor="@color/greyText"
         app:layout_constraintEnd_toEndOf="parent"

--- a/localization_ui/src/main/res/color/info_menu_color_list.xml
+++ b/localization_ui/src/main/res/color/info_menu_color_list.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/brownishOrange" android:state_checked="true" />
-    <item android:color="@color/gray" />
-</selector>

--- a/map/src/main/AndroidManifest.xml
+++ b/map/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
 
     <application>
 
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+
         <activity
             android:name=".MapActivity"
             android:theme="@style/AppTheme.CustomToolbar.MapTheme"

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -6,11 +6,9 @@ dependencies {
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
 
-    def withoutX = { exclude group: 'com.android.support', module: 'support-media-compat' }
-
     implementation libs.exo_player_core
     implementation libs.exo_player_dash
-    implementation libs.exo_player_ui, withoutX
+    implementation libs.exo_player_ui
     implementation libs.media_compat
     implementation libs.glide
     implementation libs.exo_player_media_session

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -6,9 +6,12 @@ dependencies {
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
 
+    def withoutX = { exclude group: 'com.android.support', module: 'support-media-compat' }
+
     implementation libs.exo_player_core
     implementation libs.exo_player_dash
-    implementation libs.exo_player_ui
+    implementation libs.exo_player_ui, withoutX
+    implementation libs.media_compat
     implementation libs.glide
     implementation libs.exo_player_media_session
     implementation project(':base')

--- a/media/src/main/AndroidManifest.xml
+++ b/media/src/main/AndroidManifest.xml
@@ -7,4 +7,6 @@
             android:enabled="true"
             android:exported="false" />
     </application>
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 </manifest>

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -309,8 +309,8 @@ class AudioPlayerService : DaggerService(), PlayerService {
                         return mutableListOf(CANCEL_ACTION)
                     }
 
-                    override fun createCustomActions(context: Context?): MutableMap<String, NotificationCompat.Action> {
-                        val playIntent = Intent(CANCEL_ACTION).setPackage(context?.packageName)
+                    override fun createCustomActions(context: Context, instanceId: Int): MutableMap<String, NotificationCompat.Action> {
+                        val playIntent = Intent(CANCEL_ACTION).setPackage(context.packageName)
                         return mutableMapOf(CANCEL_ACTION to NotificationCompat.Action(
                                 R.drawable.ic_close_circle,
                                 "Close",
@@ -411,7 +411,8 @@ class AudioPlayerService : DaggerService(), PlayerService {
         audioManager.isSpeakerphoneOn = false
         AudioFocusExoPlayerDecorator(audioAttributes,
                 audioManager,
-                ExoPlayerFactory.newSimpleInstance(DefaultRenderersFactory(this),
+                ExoPlayerFactory.newSimpleInstance(this,
+                        DefaultRenderersFactory(this),
                         DefaultTrackSelector(),
                         DefaultLoadControl()).apply {
                     audioAttributes = AudioAttributes.Builder()

--- a/navigation/src/main/res/values/styles.xml
+++ b/navigation/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
         <item name="layout_constraintBottom_toBottomOf">parent</item>
         <item name="layout_constraintEnd_toEndOf">parent</item>
         <item name="layout_constraintStart_toStartOf">parent</item>
+        <item name="labelVisibilityMode">labeled</item>
         <item name="menu">@menu/navigation_menu</item>
     </style>
 </resources>

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -87,7 +87,7 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
         viewModel.cells
                 .delay(50, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { resultsRV.layoutManager.scrollToPosition(0) }
+                .subscribe { resultsRV.layoutManager?.scrollToPosition(0) }
                 .disposedBy(disposeBag)
 
 

--- a/tours/src/main/kotlin/edu/artic/tours/recyclerview/AllToursItemDecoration.kt
+++ b/tours/src/main/kotlin/edu/artic/tours/recyclerview/AllToursItemDecoration.kt
@@ -14,7 +14,7 @@ class AllToursItemDecoration(
     private val horizontalSpacing: Int = context.resources.getDimension(R.dimen.all_tour_cell_spacing_horizontal).toInt()
     private val verticalSpacing: Int = context.resources.getDimension(R.dimen.all_tour_cell_spacing_vertical).toInt()
 
-    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State?) {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         var position = parent.getChildAdapterPosition(view) // item position
         if(position <= 0) {
             outRect.set(0,0,0,0)

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -43,13 +43,13 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
         }
 
         // update our content when offset changes.
-        addOnOffsetChangedListener { aBarLayout, verticalOffset ->
+        addOnOffsetChangedListener(OnOffsetChangedListener { aBarLayout, verticalOffset ->
             val progress: Double = 1 - Math.abs(verticalOffset) / aBarLayout.totalScrollRange.toDouble()
             searchIcon.background.alpha = (progress * 255).toInt()
             icon.drawable.alpha = (progress * 255).toInt()
             expandedImage.drawable.alpha = (progress * 255).toInt()
             subTitle.alpha = progress.toFloat()
-        }
+        })
 
         postDelayed( {
             collapsingToolbar.expandedTitleMarginBottom = container.getChildAt(2).height

--- a/ui/src/main/res/layout/view_app_bar_layout.xml
+++ b/ui/src/main/res/layout/view_app_bar_layout.xml
@@ -69,10 +69,10 @@
                 android:gravity="center"
                 android:paddingStart="@dimen/marginActivitySubtitle"
                 android:paddingTop="@dimen/marginHalf"
-                android:paddingEnd="@dimen/marginActivitySubtitle"
                 android:paddingBottom="@dimen/marginTriple"
+                android:paddingEnd="@dimen/marginActivitySubtitle"
                 app:layout_collapseMode="parallax"
-                tools:maxLines="3"
+                tools:maxLines="2"
                 tools:text="@tools:sample/lorem/random" />
         </LinearLayout>
 


### PR DESCRIPTION
This covers the following changes:
* Upgrade `target` and `compile` sdks from `27` (Oreo) to `28` (Pie).
* Upgrade Exoplayer media dependency
*# from `2.8.2` to `2.9.0`
*# suppress attempts thereof to bring in older support lib dependencies
* Add explicit network security configuration
*# This currently forbids cleartext (`http://` instead of `https://`) traffic to all hosts by default
*# One exception is in place for `artic.edu`, to be removed once we receive confirmation from the server team
* Use the new `app:lineHeight` attribute to enforce specific text stylings on certain `event`- and `exhibition`-related layouts