### PR TITLE
Add pressed states to language selection screen

### DIFF
--- a/access_card/src/main/res/drawable/sign_in_background.xml
+++ b/access_card/src/main/res/drawable/sign_in_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/brownishOrange" android:state_enabled="true" />
+    <item android:drawable="@drawable/detail_button_background" android:state_enabled="true" />
     <item android:drawable="@color/gray" android:state_enabled="false" />
 </selector>

--- a/access_card/src/main/res/layout/layout_member_information_form.xml
+++ b/access_card/src/main/res/layout/layout_member_information_form.xml
@@ -29,13 +29,15 @@
         android:layout_marginStart="@dimen/marginDouble"
         android:layout_marginTop="@dimen/marginOneHalf"
         android:layout_marginEnd="@dimen/marginDouble"
+        android:importantForAutofill="no"
         android:background="@color/infoInputFieldWhite"
         android:inputType="number"
         android:padding="@dimen/marginStandard"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/memberIdLabel"
-        tools:text="sampleid123" />
+        tools:targetApi="o"
+        tools:text="23456789" />
 
     <TextView
         android:id="@+id/homeZipCode"
@@ -58,13 +60,15 @@
         android:layout_marginStart="@dimen/marginDouble"
         android:layout_marginEnd="@dimen/marginDouble"
         android:layout_marginTop="@dimen/marginOneHalf"
+        android:autofillHints="postalCode"
         android:background="@color/infoInputFieldWhite"
         android:inputType="number"
         android:padding="@dimen/marginStandard"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/homeZipCode"
-        tools:text="222-346-1234" />
+        tools:targetApi="o"
+        tools:text="@tools:sample/us_zipcodes" />
 
     <Button
         android:id="@+id/signIn"
@@ -79,7 +83,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/zipCode"
-        tools:background="@color/brownish_orange"
         tools:enabled="false" />
 
 </android.support.constraint.ConstraintLayout>

--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="toolbarStyle">@style/Widget.AppCompat.Toolbar.Ideal</item>
+        <item name="buttonStyle">@style/Widget.AppCompat.Button.Tinted</item>
         <item name="android:fontFamily">@font/ideal_sans_book</item>
         <item name="android:fontFeatureSettings">tnum</item>
         <item name="android:statusBarColor">@color/colorPrimary</item>
@@ -34,6 +35,10 @@
 
     <style name="Widget.AppCompat.Toolbar.Ideal">
         <item name="titleTextAppearance">@style/AppBarTitleWhite</item>
+    </style>
+
+    <style name="Widget.AppCompat.Button.Tinted">
+        <item name="android:background">@drawable/detail_button_background</item>
     </style>
 
     <style name="DetailToolbarExpandedText">
@@ -177,8 +182,7 @@
         <item name="android:textSize">15sp</item>
     </style>
 
-    <style name="DetailButtonParent" parent="Widget.AppCompat.Button">
-        <item name="android:background">@drawable/detail_button_background</item>
+    <style name="DetailButtonParent" parent="Widget.AppCompat.Button.Tinted">
         <item name="android:gravity">center</item>
         <item name="android:minHeight">50dp</item>
     </style>

--- a/info/src/main/res/layout/fragment_information.xml
+++ b/info/src/main/res/layout/fragment_information.xml
@@ -98,7 +98,6 @@
                 android:layout_marginStart="@dimen/marginDouble"
                 android:layout_marginTop="@dimen/marginTwenty"
                 android:layout_marginEnd="@dimen/marginDouble"
-                android:background="@color/brownishOrange"
                 android:text="@string/accessMemberCardLabel"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/localization_ui/src/main/res/drawable/language_button_background.xml
+++ b/localization_ui/src/main/res/drawable/language_button_background.xml
@@ -28,9 +28,7 @@
         <shape android:shape="rectangle">
             <corners android:radius="@dimen/abc_control_corner_material"/>
             <!-- For the background, use a non-transparent color -->
-            <solid
-                android:color="?attr/languageSettingsBackgroundColor"
-                />
+            <solid android:color="?attr/languageSettingsBackgroundColor"/>
             <!-- And for the foreground, use attr/languageSettingsButtonTextColor to extend theme control -->
             <stroke
                 android:width="1dp"

--- a/localization_ui/src/main/res/drawable/language_button_background.xml
+++ b/localization_ui/src/main/res/drawable/language_button_background.xml
@@ -3,5 +3,5 @@
     android:shape="rectangle">
     <stroke
         android:width="1dp"
-        android:color="@color/brownish_orange"/>
+        android:color="?attr/languageSettingsButtonTextColor"/>
 </shape>

--- a/localization_ui/src/main/res/drawable/language_button_background.xml
+++ b/localization_ui/src/main/res/drawable/language_button_background.xml
@@ -1,7 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <stroke
-        android:width="1dp"
-        android:color="?attr/languageSettingsButtonTextColor"/>
-</shape>
+<!-- Copyright (C) 2014 The Android Open Source Project
+     Modifications (C) 2018 Philip Cohn-Cort (Fuzz)
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- Used as the 'unchecked' button shape. -->
+
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="PrivateResource"
+    android:color="?attr/colorControlHighlight"
+    >
+    <item>
+        <!-- This 'item' is derived from AOSP's abc_btn_default_mtrl_shape.xml. We do not want an inset here. -->
+        <shape android:shape="rectangle">
+            <corners android:radius="@dimen/abc_control_corner_material"/>
+            <!-- For the background, use a non-transparent color -->
+            <solid
+                android:color="?attr/languageSettingsBackgroundColor"
+                />
+            <!-- And for the foreground, use attr/languageSettingsButtonTextColor to extend theme control -->
+            <stroke
+                android:width="1dp"
+                android:color="?attr/languageSettingsButtonTextColor"
+                />
+            <padding
+                android:bottom="@dimen/abc_button_padding_vertical_material"
+                android:left="@dimen/abc_button_padding_horizontal_material"
+                android:right="@dimen/abc_button_padding_horizontal_material"
+                android:top="@dimen/abc_button_padding_vertical_material"
+                />
+        </shape>
+    </item>
+</ripple>

--- a/localization_ui/src/main/res/drawable/language_button_tint.xml
+++ b/localization_ui/src/main/res/drawable/language_button_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<color
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorAccent"
+    />

--- a/localization_ui/src/main/res/drawable/language_radio_button_background.xml
+++ b/localization_ui/src/main/res/drawable/language_radio_button_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:drawable="@color/brownish_orange" android:state_checked="true" />
+    <item android:drawable="@drawable/language_button_tint" android:state_checked="true" />
     <item android:drawable="@drawable/language_button_background" android:state_checked="false" />
 
 </selector>

--- a/localization_ui/src/main/res/values/styles.xml
+++ b/localization_ui/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LanguageButton">
+    <style name="LanguageButton" parent="Widget.AppCompat.Button">
         <item name="android:textAllCaps">false</item>
         <item name="android:fontFamily">@font/ideal_sans_medium</item>
         <item name="android:textSize">15sp</item>

--- a/media_ui/src/main/res/layout/activity_audio_tutorial.xml
+++ b/media_ui/src/main/res/layout/activity_audio_tutorial.xml
@@ -51,7 +51,6 @@
         android:layout_marginStart="@dimen/marginDouble"
         android:layout_marginEnd="@dimen/marginDouble"
         android:layout_marginBottom="@dimen/okButtonBottomMargin"
-        android:background="@drawable/detail_button_background"
         android:text="@android:string/ok"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/splash/src/main/res/drawable/splash_language_button_background.xml
+++ b/splash/src/main/res/drawable/splash_language_button_background.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <stroke
-        android:width="1dp"
-        android:color="@color/white"/>
-</shape>

--- a/splash/src/main/res/drawable/splash_language_radio_button_background.xml
+++ b/splash/src/main/res/drawable/splash_language_radio_button_background.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/sea" android:state_checked="true" />
-    <item android:drawable="@drawable/splash_language_button_background" android:state_checked="false" />
-</selector>

--- a/splash/src/main/res/values/styles.xml
+++ b/splash/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
         <item name="languageSettingsBodyTextColor">@color/white</item>
         <item name="languageSettingsTitleTextColor">@color/white</item>
         <item name="languageSettingsHasDivider">false</item>
-        <item name="languageSettingsButtonVerticalBias">0.5</item>
+        <item name="languageSettingsButtonVerticalBias">0.8</item>
         <item name="languageSettingsTitleTextAppearance">@style/LanguageSettingsText</item>
         <item name="languageSettingsBodyTextAppearance">@style/BodySansSerifWhiteCentered</item>
     </style>

--- a/splash/src/main/res/values/styles.xml
+++ b/splash/src/main/res/values/styles.xml
@@ -4,10 +4,12 @@
     <style name="SplashTheme" parent="AppTheme.CustomToolbar">
         <item name="colorPrimaryDark">@color/colorPrimary</item>
         <item name="android:windowBackground">@drawable/splash_gradient</item>
-        <item name="colorAccent">@color/white</item>
+        <item name="colorAccent">@color/sea</item>
+
+        <!-- Attributes for edu.artic.localization.ui.LanguageSettingsFragment -->
         <item name="languageSettingsBackgroundColor">@color/ugly_blue</item>
         <item name="languageSettingsButtonTextColor">@color/white</item>
-        <item name="languageSettingsButtonBackground">@drawable/splash_language_radio_button_background</item>
+        <item name="languageSettingsButtonBackground">@drawable/language_radio_button_background</item>
         <item name="languageSettingsContainsToolbar">false</item>
         <item name="languageSettingsBodyTextColor">@color/white</item>
         <item name="languageSettingsTitleTextColor">@color/white</item>


### PR DESCRIPTION
This adds a few more button stylings, primarily to the buttons shown on the two language selection screens (i.e. the one from the splash sequence and the one under the `info` section).