### PR TITLE
Remove anchor links from html (AIC-567)

### DIFF
--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -100,7 +100,7 @@ class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
 
         viewModel.description
                 .map {
-                    it.trimDownBlankLines().fromHtml(Html.FROM_HTML_MODE_COMPACT)
+                    it.trimDownBlankLines().fromHtml()
                 }
                 .bindToMain(description.text())
                 .disposedBy(disposeBag)


### PR DESCRIPTION
Very simple: all `ClickableSpan`s are now removed from html text.