### PR TITLE
Hide button on Event Detail screen if there's no url to back it up (AIC-568)

### DIFF
--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -3,7 +3,6 @@ package edu.artic.events
 import android.os.Bundle
 import android.support.v4.math.MathUtils
 import android.support.v4.widget.NestedScrollView
-import android.text.Html
 import android.view.View
 import android.widget.ImageView
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
@@ -24,6 +23,7 @@ import edu.artic.image.ImageViewScaleInfo
 import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
+import io.reactivex.rxkotlin.Observables
 import kotlinx.android.synthetic.main.fragment_event_details.*
 import kotlin.reflect.KClass
 
@@ -114,9 +114,13 @@ class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
                 .bindToMain(location.text())
                 .disposedBy(disposeBag)
 
-        viewModel.eventButtonText
-                .map { it.isNotEmpty() }
+        Observables.combineLatest(
+                viewModel.eventButtonText.map { it.isNotEmpty() },
+                viewModel.hasEventUrl
+        )
+                .map { it.first && it.second }
                 .bindToMain(registerToday.visibility())
+                .disposedBy(disposeBag)
 
 
         viewModel.eventButtonText

--- a/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
@@ -31,6 +31,7 @@ class EventDetailViewModel @Inject constructor(
     val throughDate: Subject<String> = BehaviorSubject.createDefault("")
     val location: Subject<String> = BehaviorSubject.createDefault("")
     val eventButtonText: Subject<String> = BehaviorSubject.createDefault("")
+    val hasEventUrl: Subject<Boolean> = BehaviorSubject.create()
     private val eventObservable: Subject<ArticEvent> = BehaviorSubject.create()
 
 
@@ -49,6 +50,11 @@ class EventDetailViewModel @Inject constructor(
                     it.button_text.orEmpty()
                 }
                 .bindTo(eventButtonText)
+                .disposedBy(disposeBag)
+
+        eventObservable
+                .map { !it.button_url.isNullOrBlank() }
+                .bindTo(hasEventUrl)
                 .disposedBy(disposeBag)
 
         eventObservable


### PR DESCRIPTION
Some of our events have empty url endpoints. This makes sure buttons related to those are hidden.