### PR TITLE
Increase version number to 0.7 to mark improvements since the first 0.6.1 build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ if (project.hasProperty('build_number')) {
     buildMetadata = 'SNAPSHOT'
 }
 
-String majorAndMinorVersion = "0.6"
-Integer patchVersionCode = 1000
+String majorAndMinorVersion = "0.7"
+Integer patchVersionCode = 0
 
 android {
     compileSdkVersion sdk
@@ -23,7 +23,7 @@ android {
         minSdkVersion minSdk
         targetSdkVersion sdk
         multiDexEnabled true
-        versionCode patchVersionCode
+        versionCode (patchVersionCode + 1000)
         versionName "$majorAndMinorVersion.$patchVersionCode"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
This is a little overdue, but ultimately it should be quite helpful. I'm keeping the manifest version code at `1000` for now - we might need to coordinate a nicer upgrade strategy in future, but for now I think we can just hard-code an offset for that property.