### PR TITLE
Updates correct event category for analytics  - (AIC-552)

### DIFF
--- a/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
+++ b/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
@@ -41,7 +41,7 @@ class AccessMemberCardFragment : BaseViewModelFragment<AccessMemberCardViewModel
     override val viewModelClass: KClass<AccessMemberCardViewModel> = AccessMemberCardViewModel::class
     override val title = R.string.accessMemberCardLabel
     override val layoutResId: Int = R.layout.fragment_validate_member_information
-    override val screenCategory: ScreenCategoryName? = null
+    override val screenName: ScreenCategoryName? = null
 
     private lateinit var toolbarColorAnimator: ValueAnimator
 

--- a/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
+++ b/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
@@ -19,7 +19,7 @@ import com.jakewharton.rxbinding2.widget.hintRes
 import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textChanges
 import edu.artic.accesscard.barcode.BarcodeEncoder
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.LoadStatus
 import edu.artic.base.utils.hideSoftKeyboard
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -41,7 +41,7 @@ class AccessMemberCardFragment : BaseViewModelFragment<AccessMemberCardViewModel
     override val viewModelClass: KClass<AccessMemberCardViewModel> = AccessMemberCardViewModel::class
     override val title = R.string.accessMemberCardLabel
     override val layoutResId: Int = R.layout.fragment_validate_member_information
-    override val screenName: ScreenCategoryName? = null
+    override val screenName: ScreenName? = null
 
     private lateinit var toolbarColorAnimator: ValueAnimator
 

--- a/analytics/src/main/java/edu/artic/analytics/AnalyticsTracker.kt
+++ b/analytics/src/main/java/edu/artic/analytics/AnalyticsTracker.kt
@@ -22,7 +22,7 @@ interface AnalyticsTracker {
 
     fun reportEvent(category: String, action: String = "", label: String = "")
 
-    fun reportEvent(categoryName: ScreenCategoryName, action: String = "", label: String = "") =
+    fun reportEvent(categoryName: ScreenName, action: String = "", label: String = "") =
             reportEvent(categoryName.screenName, action, label)
 
     fun reportEvent(categoryName: EventCategoryName, action: String = "", label: String = "") =
@@ -30,7 +30,7 @@ interface AnalyticsTracker {
 
     fun reportScreenView(name: String)
 
-    fun reportScreenView(categoryName: ScreenCategoryName) = reportScreenView(categoryName.screenName)
+    fun reportScreenView(categoryName: ScreenName) = reportScreenView(categoryName.screenName)
 }
 
 class AnalyticsTrackerImpl(context: Context,

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -107,8 +107,6 @@ object AnalyticsAction {
     const val searchCategorySwitched = "category_switched"
 
     const val errorsAudioGuideFail = "audio_guide_fail"
-
-    const val headingEnabled = "headingEnabled"
 }
 
 object AnalyticsLabel {

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -51,6 +51,7 @@ sealed class EventCategoryName(val eventCategoryName: String) {
     object SearchArtwork : EventCategoryName("search_artwork")
     object SearchPlayArtwork : EventCategoryName("search_play_artwork")
     object Member : EventCategoryName("member")
+    object Map : EventCategoryName("map")
     object Location : EventCategoryName("location")
 }
 

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -35,6 +35,7 @@ sealed class ScreenCategoryName(val screenName: String) {
 sealed class EventCategoryName(val eventCategoryName: String) {
     object App : EventCategoryName("app")
     object Exhibition : EventCategoryName("exhibition")
+    object Event : EventCategoryName("event")
     /**
      * NB: actions in this category may be `Locale.nameOfLanguageForAnalytics()` instead of a constant from this file.
      */

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -35,6 +35,7 @@ sealed class ScreenCategoryName(val screenName: String) {
 
 sealed class EventCategoryName(val eventCategoryName: String) {
     object App : EventCategoryName("app")
+    object Exhibition : EventCategoryName("exhibition")
     /**
      * NB: actions in this category may be `Locale.nameOfLanguageForAnalytics()` instead of a constant from this file.
      */

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -9,26 +9,26 @@ package edu.artic.analytics
  * * Label (optional)
  * * Value (optional)
  */
-sealed class ScreenCategoryName(val screenName: String) {
-    object Home : ScreenCategoryName("Home")
-    object AudioGuide : ScreenCategoryName("Audio Guide")
-    object Map : ScreenCategoryName("Map")
-    object Information : ScreenCategoryName("Information")
-    object MuseumInformation : ScreenCategoryName("Museum Information")
-    object LanguageSettings : ScreenCategoryName("Language Settings")
-    object LocationSettings : ScreenCategoryName("Location Settings")
-    object Events : ScreenCategoryName("Events")
-    object OnView : ScreenCategoryName("On View")
-    object Tours : ScreenCategoryName("Tours")
-    object Search : ScreenCategoryName("Search")
-    object AudioPlayer : ScreenCategoryName("Audio Player")
-    object TourDetails : ScreenCategoryName("Tour Details")
-    object OnViewDetails : ScreenCategoryName("On View Details")
-    object EventDetails : ScreenCategoryName("Event Details")
-    object ArtworkSearchDetails : ScreenCategoryName("Artwork Search Details")
+sealed class ScreenName(val screenName: String) {
+    object Home : ScreenName("Home")
+    object AudioGuide : ScreenName("Audio Guide")
+    object Map : ScreenName("Map")
+    object Information : ScreenName("Information")
+    object MuseumInformation : ScreenName("Museum Information")
+    object LanguageSettings : ScreenName("Language Settings")
+    object LocationSettings : ScreenName("Location Settings")
+    object Events : ScreenName("Events")
+    object OnView : ScreenName("On View")
+    object Tours : ScreenName("Tours")
+    object Search : ScreenName("Search")
+    object AudioPlayer : ScreenName("Audio Player")
+    object TourDetails : ScreenName("Tour Details")
+    object OnViewDetails : ScreenName("On View Details")
+    object EventDetails : ScreenName("Event Details")
+    object ArtworkSearchDetails : ScreenName("Artwork Search Details")
 
     override fun toString(): String {
-        return "ScreenCategoryName(screenName='$screenName')"
+        return "ScreenName(screenName='$screenName')"
     }
 }
 

--- a/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
+++ b/analytics/src/main/java/edu/artic/analytics/ScreenConstants.kt
@@ -19,7 +19,6 @@ sealed class ScreenCategoryName(val screenName: String) {
     object LocationSettings : ScreenCategoryName("Location Settings")
     object Events : ScreenCategoryName("Events")
     object OnView : ScreenCategoryName("On View")
-    object Exhibition : ScreenCategoryName("Exhibition")
     object Tours : ScreenCategoryName("Tours")
     object Search : ScreenCategoryName("Search")
     object AudioPlayer : ScreenCategoryName("Audio Player")

--- a/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
@@ -49,7 +49,7 @@ class AudioLookupFragment : BaseViewModelFragment<AudioLookupViewModel>() {
 
     override val layoutResId: Int
         get() = R.layout.fragment_audio_lookup
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.AudioGuide
 
     override fun hasTransparentStatusBar(): Boolean {

--- a/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioLookupFragment.kt
@@ -14,7 +14,7 @@ import com.jakewharton.rxbinding2.widget.hint
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicks
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.db.models.ArticObject
 import edu.artic.media.ui.getAudioServiceObservable
@@ -49,8 +49,8 @@ class AudioLookupFragment : BaseViewModelFragment<AudioLookupViewModel>() {
 
     override val layoutResId: Int
         get() = R.layout.fragment_audio_lookup
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.AudioGuide
+    override val screenName: ScreenName
+        get() = ScreenName.AudioGuide
 
     override fun hasTransparentStatusBar(): Boolean {
         return true

--- a/audio/src/main/java/edu/artic/audio/AudioLookupViewModel.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioLookupViewModel.kt
@@ -7,7 +7,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.EventCategoryName
 import edu.artic.audio.LookupResult.FoundAudio
 import edu.artic.audio.LookupResult.NotFound
 import edu.artic.audio.NumberPadElement.*
@@ -143,7 +143,7 @@ class AudioLookupViewModel @Inject constructor(
         audioService?.let{
             // Send Analytics for 'playback initiated'
             analyticsTracker.reportEvent(
-                    ScreenCategoryName.AudioGuide,
+                    EventCategoryName.PlayAudio,
                     AnalyticsAction.playAudioAudioGuide,
                     foundAudio.hostObject.title
             )

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
@@ -30,7 +30,7 @@ class ArtworkDetailFragment : BaseViewModelFragment<ArtworkDetailViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_search_audio_detail
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = ScreenCategoryName.ArtworkSearchDetails
 
     private val articObject by lazy { arguments!!.getParcelable<ArticSearchArtworkObject>(ARG_OBJECT) }

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
@@ -16,6 +16,7 @@ import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.details.R
 import edu.artic.image.GlideApp
+import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.media.ui.getAudioServiceObservable
 import edu.artic.navigation.NavigationConstants
 import edu.artic.viewmodel.BaseViewModelFragment

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
@@ -11,12 +11,11 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.details.R
 import edu.artic.image.GlideApp
-import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.media.ui.getAudioServiceObservable
 import edu.artic.navigation.NavigationConstants
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -30,8 +29,8 @@ class ArtworkDetailFragment : BaseViewModelFragment<ArtworkDetailViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_search_audio_detail
-    override val screenName: ScreenCategoryName?
-        get() = ScreenCategoryName.ArtworkSearchDetails
+    override val screenName: ScreenName?
+        get() = ScreenName.ArtworkSearchDetails
 
     private val articObject by lazy { arguments!!.getParcelable<ArticSearchArtworkObject>(ARG_OBJECT) }
     private val searchTerm by lazy { arguments!!.getString(ARG_SEARCH_TERM) }

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
@@ -99,7 +99,7 @@ class ArtworkDetailViewModel @Inject constructor(
 
     fun onClickShowOnMap() {
         articObject?.let { articObj ->
-            analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowArtwork, articObj.title)
+            analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowArtwork, articObj.title)
             navigateTo.onNext(
                     Navigate.Forward(
                             NavigationEndpoint.ObjectOnMap(articObj)

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
@@ -6,7 +6,6 @@ import com.fuzz.rx.filterFlatMap
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
 import edu.artic.db.Playable
 import edu.artic.db.models.ArticSearchArtworkObject
 import edu.artic.db.models.audioFile

--- a/details/src/main/kotlin/edu/artic/details/EmptyDetailsFragment.kt
+++ b/details/src/main/kotlin/edu/artic/details/EmptyDetailsFragment.kt
@@ -8,7 +8,7 @@ class EmptyDetailsFragment: BaseFragment() {
         get() = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_empty_details
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = null
 
 

--- a/details/src/main/kotlin/edu/artic/details/EmptyDetailsFragment.kt
+++ b/details/src/main/kotlin/edu/artic/details/EmptyDetailsFragment.kt
@@ -1,6 +1,6 @@
 package edu.artic.details
 
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.ui.BaseFragment
 
 class EmptyDetailsFragment: BaseFragment() {
@@ -8,7 +8,7 @@ class EmptyDetailsFragment: BaseFragment() {
         get() = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_empty_details
-    override val screenName: ScreenCategoryName?
+    override val screenName: ScreenName?
         get() = null
 
 

--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -12,7 +12,7 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asUrlViewIntent
 import edu.artic.base.utils.fromHtml
 import edu.artic.base.utils.trimDownBlankLines
@@ -20,7 +20,6 @@ import edu.artic.db.models.ArticEvent
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
-import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.rxkotlin.Observables
@@ -28,8 +27,8 @@ import kotlinx.android.synthetic.main.fragment_event_details.*
 import kotlin.reflect.KClass
 
 class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.EventDetails
+    override val screenName: ScreenName
+        get() = ScreenName.EventDetails
     override val viewModelClass: KClass<EventDetailViewModel>
         get() = EventDetailViewModel::class
     override val layoutResId: Int

--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.fragment_event_details.*
 import kotlin.reflect.KClass
 
 class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.EventDetails
     override val viewModelClass: KClass<EventDetailViewModel>
         get() = EventDetailViewModel::class

--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -20,6 +20,7 @@ import edu.artic.db.models.ArticEvent
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
+import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.rxkotlin.Observables

--- a/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
@@ -5,7 +5,6 @@ import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
 import edu.artic.localization.util.DateTimeHelper.Purpose.*
 import edu.artic.db.models.ArticEvent
 import edu.artic.localization.LanguageSelector

--- a/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailViewModel.kt
@@ -4,6 +4,7 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.analytics.EventCategoryName
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.localization.util.DateTimeHelper.Purpose.*
 import edu.artic.db.models.ArticEvent
@@ -109,7 +110,7 @@ class EventDetailViewModel @Inject constructor(
 
     fun onClickRegisterToday() {
         event?.let {
-            analyticsTracker.reportEvent(ScreenCategoryName.Events, AnalyticsAction.linkPressed, it.title)
+            analyticsTracker.reportEvent(EventCategoryName.Event, AnalyticsAction.linkPressed, it.title)
             navigateTo.onNext(Navigate.Forward(NavigationEndpoint.LoadUrl(it.buttonURL)))
         }
     }

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -20,6 +20,7 @@ import edu.artic.db.models.ArticExhibition
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
+import edu.artic.image.listenerSetHeight
 import edu.artic.navigation.NavigationConstants
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
  */
 class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel>() {
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.OnViewDetails
 
     override val viewModelClass: KClass<ExhibitionDetailViewModel>

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -11,17 +11,15 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
-import com.jakewharton.rxbinding2.widget.textRes
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.asUrlViewIntent
 import edu.artic.db.models.ArticExhibition
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
-import edu.artic.image.listenerSetHeight
 import edu.artic.navigation.NavigationConstants
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
@@ -37,8 +35,8 @@ import kotlin.reflect.KClass
  */
 class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel>() {
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.OnViewDetails
+    override val screenName: ScreenName
+        get() = ScreenName.OnViewDetails
 
     override val viewModelClass: KClass<ExhibitionDetailViewModel>
         get() = ExhibitionDetailViewModel::class

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -13,6 +13,7 @@ import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textRes
 import edu.artic.analytics.AnalyticsAction
+import edu.artic.analytics.EventCategoryName
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.asUrlViewIntent
@@ -146,7 +147,7 @@ class ExhibitionDetailFragment : BaseViewModelFragment<ExhibitionDetailViewModel
 
                             when (endpoint) {
                                 is ExhibitionDetailViewModel.NavigationEndpoint.ShowOnMap -> {
-                                    analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowExhibition, exhibition.title)
+                                    analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowExhibition, exhibition.title)
                                     val mapIntent = NavigationConstants.MAP.asDeepLinkIntent().apply {
                                         putExtra(NavigationConstants.ARG_EXHIBITION_OBJECT, exhibition)
                                         flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
@@ -3,10 +3,7 @@ package edu.artic.exhibitions
 import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import com.fuzz.rx.filterFlatMap
-import edu.artic.analytics.AnalyticsAction
-import edu.artic.analytics.AnalyticsLabel
-import edu.artic.analytics.AnalyticsTracker
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.*
 import edu.artic.localization.util.DateTimeHelper.Purpose.*
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.daos.ArticGalleryDao
@@ -107,7 +104,7 @@ constructor(dataObjectDao: ArticDataObjectDao,
 
     fun onClickBuyTickets() {
         ticketsUrl?.let { url ->
-            analyticsTracker.reportEvent(ScreenCategoryName.Exhibition, AnalyticsAction.linkPressed, exhibition?.title
+            analyticsTracker.reportEvent(EventCategoryName.Exhibition, AnalyticsAction.linkPressed, exhibition?.title
                     ?: AnalyticsLabel.Empty)
             navigateTo.onNext(Navigate.Forward(NavigationEndpoint.BuyTickets(url)))
         }

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
@@ -17,7 +17,7 @@ import com.jakewharton.rxbinding2.widget.itemSelections
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.*
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.dpToPixels
 import edu.artic.base.utils.fromHtml
@@ -25,7 +25,6 @@ import edu.artic.db.models.ArticTour
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
-import edu.artic.image.updateImageScaleType
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
 import edu.artic.localization.SpecifiesLanguage
@@ -49,8 +48,8 @@ class TourDetailsFragment : BaseViewModelFragment<TourDetailsViewModel>() {
 
     override val title = R.string.noTitle
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.TourDetails
+    override val screenName: ScreenName
+        get() = ScreenName.TourDetails
 
     override val customToolbarColorResource: Int
         get() = R.color.audioBackground

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
@@ -49,7 +49,7 @@ class TourDetailsFragment : BaseViewModelFragment<TourDetailsViewModel>() {
 
     override val title = R.string.noTitle
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.TourDetails
 
     override val customToolbarColorResource: Int

--- a/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
+++ b/details/src/main/kotlin/edu/artic/tours/TourDetailsFragment.kt
@@ -25,6 +25,7 @@ import edu.artic.db.models.ArticTour
 import edu.artic.details.R
 import edu.artic.image.GlideApp
 import edu.artic.image.ImageViewScaleInfo
+import edu.artic.image.updateImageScaleType
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
 import edu.artic.localization.SpecifiesLanguage

--- a/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
+++ b/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
@@ -10,7 +10,7 @@ import com.fuzz.rx.filterTo
 import com.jakewharton.rxbinding2.view.clicks
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.events.recyclerview.AllEventsItemDecoration
 import edu.artic.navigation.NavigationConstants
@@ -22,8 +22,8 @@ import kotlin.reflect.KClass
 
 class AllEventsFragment : BaseViewModelFragment<AllEventsViewModel>() {
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Events
+    override val screenName: ScreenName
+        get() = ScreenName.Events
 
     override val viewModelClass: KClass<AllEventsViewModel>
         get() = AllEventsViewModel::class

--- a/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
+++ b/events/src/main/kotlin/edu/artic/events/AllEventsFragment.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
 
 class AllEventsFragment : BaseViewModelFragment<AllEventsViewModel>() {
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Events
 
     override val viewModelClass: KClass<AllEventsViewModel>

--- a/events/src/main/kotlin/edu/artic/events/AllEventsViewModel.kt
+++ b/events/src/main/kotlin/edu/artic/events/AllEventsViewModel.kt
@@ -5,6 +5,7 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
+import edu.artic.analytics.EventCategoryName
 import edu.artic.analytics.ScreenCategoryName
 import edu.artic.localization.util.DateTimeHelper.Purpose.*
 import edu.artic.db.daos.ArticEventDao
@@ -69,7 +70,7 @@ class AllEventsViewModel @Inject constructor(
     }
 
     fun onClickEvent(pos: Int, event: ArticEvent) {
-        analyticsTracker.reportEvent(ScreenCategoryName.Events, AnalyticsAction.OPENED, event.title)
+        analyticsTracker.reportEvent(EventCategoryName.Event, AnalyticsAction.OPENED, event.title)
         navigateTo.onNext(Navigate.Forward(NavigationEndpoint.EventDetail(pos, event)))
     }
 

--- a/events/src/main/kotlin/edu/artic/events/AllEventsViewModel.kt
+++ b/events/src/main/kotlin/edu/artic/events/AllEventsViewModel.kt
@@ -6,7 +6,6 @@ import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
 import edu.artic.localization.util.DateTimeHelper.Purpose.*
 import edu.artic.db.daos.ArticEventDao
 import edu.artic.db.models.ArticEvent

--- a/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
+++ b/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
@@ -10,7 +10,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.exhibitions.recyclerview.AllExhibitionsItemDecoration
 import edu.artic.navigation.NavigationConstants
@@ -21,8 +21,8 @@ import kotlin.reflect.KClass
 
 class AllExhibitionsFragment : BaseViewModelFragment<AllExhibitionsViewModel>() {
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.OnView
+    override val screenName: ScreenName
+        get() = ScreenName.OnView
 
     override val viewModelClass: KClass<AllExhibitionsViewModel>
         get() = AllExhibitionsViewModel::class

--- a/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
+++ b/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsFragment.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KClass
 
 class AllExhibitionsFragment : BaseViewModelFragment<AllExhibitionsViewModel>() {
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.OnView
 
     override val viewModelClass: KClass<AllExhibitionsViewModel>

--- a/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsViewModel.kt
+++ b/exhibitions/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsViewModel.kt
@@ -6,7 +6,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.EventCategoryName
 import edu.artic.localization.util.DateTimeHelper.Purpose.HomeExhibition
 import edu.artic.db.daos.ArticExhibitionDao
 import edu.artic.db.models.ArticExhibition
@@ -48,7 +48,7 @@ class AllExhibitionsViewModel @Inject constructor(
     }
 
     fun onClickExhibition(position: Int, exhibition: ArticExhibition) {
-        analyticsTracker.reportEvent(ScreenCategoryName.Exhibition, AnalyticsAction.OPENED, exhibition.title)
+        analyticsTracker.reportEvent(EventCategoryName.Exhibition, AnalyticsAction.OPENED, exhibition.title)
         navigateTo.onNext(Navigate.Forward(NavigationEndpoint.ExhibitionDetails(position, exhibition)))
     }
 

--- a/info/src/main/java/edu/artic/info/InformationFragment.kt
+++ b/info/src/main/java/edu/artic/info/InformationFragment.kt
@@ -27,7 +27,7 @@ class InformationFragment : BaseViewModelFragment<InformationViewModel>() {
     @Inject
     lateinit var languageSelector: LanguageSelector
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Information
 
     override val viewModelClass: KClass<InformationViewModel>

--- a/info/src/main/java/edu/artic/info/InformationFragment.kt
+++ b/info/src/main/java/edu/artic/info/InformationFragment.kt
@@ -5,7 +5,7 @@ import com.fuzz.rx.defaultThrottle
 import com.fuzz.rx.disposedBy
 import com.fuzz.rx.filterFlatMap
 import com.jakewharton.rxbinding2.view.clicks
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.customTab.CustomTabManager
 import edu.artic.localization.LanguageSelector
@@ -27,8 +27,8 @@ class InformationFragment : BaseViewModelFragment<InformationViewModel>() {
     @Inject
     lateinit var languageSelector: LanguageSelector
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Information
+    override val screenName: ScreenName
+        get() = ScreenName.Information
 
     override val viewModelClass: KClass<InformationViewModel>
         get() = InformationViewModel::class

--- a/info/src/main/java/edu/artic/info/MuseumInformationFragment.kt
+++ b/info/src/main/java/edu/artic/info/MuseumInformationFragment.kt
@@ -9,7 +9,7 @@ import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textRes
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.customTab.CustomTabManager
 import edu.artic.navigation.NavigationConstants
@@ -31,7 +31,7 @@ class MuseumInformationFragment : BaseViewModelFragment<MuseumInformationViewMod
 
     override val layoutResId: Int = R.layout.fragment_museum_information
 
-    override val screenName: ScreenCategoryName = ScreenCategoryName.MuseumInformation
+    override val screenName: ScreenName = ScreenName.MuseumInformation
 
     override fun setupBindings(viewModel: MuseumInformationViewModel) {
         super.setupBindings(viewModel)

--- a/info/src/main/java/edu/artic/info/MuseumInformationFragment.kt
+++ b/info/src/main/java/edu/artic/info/MuseumInformationFragment.kt
@@ -31,7 +31,7 @@ class MuseumInformationFragment : BaseViewModelFragment<MuseumInformationViewMod
 
     override val layoutResId: Int = R.layout.fragment_museum_information
 
-    override val screenCategory: ScreenCategoryName = ScreenCategoryName.MuseumInformation
+    override val screenName: ScreenCategoryName = ScreenCategoryName.MuseumInformation
 
     override fun setupBindings(viewModel: MuseumInformationViewModel) {
         super.setupBindings(viewModel)

--- a/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
+++ b/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
@@ -23,7 +23,7 @@ class LanguageSettingsFragment : BaseViewModelFragment<LanguageSettingsViewModel
     override val viewModelClass: KClass<LanguageSettingsViewModel> = LanguageSettingsViewModel::class
     override val title = R.string.languageSettings
     override val layoutResId: Int = R.layout.fragment_language_settings
-    override val screenCategory: ScreenCategoryName? = ScreenCategoryName.LanguageSettings
+    override val screenName: ScreenCategoryName? = ScreenCategoryName.LanguageSettings
 
     /**
      * Represents [LanguageSettingsFragment] is loaded in Splash.

--- a/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
+++ b/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
@@ -8,7 +8,7 @@ import android.view.View
 import com.fuzz.rx.defaultThrottle
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.localization.SPANISH
 import edu.artic.navigation.NavigationConstants
@@ -23,7 +23,7 @@ class LanguageSettingsFragment : BaseViewModelFragment<LanguageSettingsViewModel
     override val viewModelClass: KClass<LanguageSettingsViewModel> = LanguageSettingsViewModel::class
     override val title = R.string.languageSettings
     override val layoutResId: Int = R.layout.fragment_language_settings
-    override val screenName: ScreenCategoryName? = ScreenCategoryName.LanguageSettings
+    override val screenName: ScreenName? = ScreenName.LanguageSettings
 
     /**
      * Represents [LanguageSettingsFragment] is loaded in Splash.

--- a/location_ui/src/main/java/edu/artic/location/InfoLocationSettingsFragment.kt
+++ b/location_ui/src/main/java/edu/artic/location/InfoLocationSettingsFragment.kt
@@ -23,7 +23,7 @@ class InfoLocationSettingsFragment : BaseViewModelFragment<InfoLocationSettingsV
     override val viewModelClass: KClass<InfoLocationSettingsViewModel> = InfoLocationSettingsViewModel::class
     override val title = R.string.location_title
     override val layoutResId: Int = R.layout.fragment_location_settings
-    override val screenCategory: ScreenCategoryName? = ScreenCategoryName.LocationSettings
+    override val screenName: ScreenCategoryName? = ScreenCategoryName.LocationSettings
 
 
     override fun setupBindings(viewModel: InfoLocationSettingsViewModel) {

--- a/location_ui/src/main/java/edu/artic/location/InfoLocationSettingsFragment.kt
+++ b/location_ui/src/main/java/edu/artic/location/InfoLocationSettingsFragment.kt
@@ -9,7 +9,7 @@ import com.fuzz.rx.disposedBy
 import com.fuzz.rx.filterFlatMap
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.text
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.location_ui.R
 import edu.artic.navigation.NavigationConstants
@@ -23,7 +23,7 @@ class InfoLocationSettingsFragment : BaseViewModelFragment<InfoLocationSettingsV
     override val viewModelClass: KClass<InfoLocationSettingsViewModel> = InfoLocationSettingsViewModel::class
     override val title = R.string.location_title
     override val layoutResId: Int = R.layout.fragment_location_settings
-    override val screenName: ScreenCategoryName? = ScreenCategoryName.LocationSettings
+    override val screenName: ScreenName? = ScreenName.LocationSettings
 
 
     override fun setupBindings(viewModel: InfoLocationSettingsViewModel) {

--- a/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
+++ b/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.View
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.location_ui.R
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
@@ -20,7 +20,7 @@ class LocationPromptFragment : BaseViewModelFragment<LocationPromptViewModel>() 
     override val viewModelClass: KClass<LocationPromptViewModel> = LocationPromptViewModel::class
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_location_prompt
-    override val screenName: ScreenCategoryName? = null
+    override val screenName: ScreenName? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
+++ b/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
@@ -20,7 +20,7 @@ class LocationPromptFragment : BaseViewModelFragment<LocationPromptViewModel>() 
     override val viewModelClass: KClass<LocationPromptViewModel> = LocationPromptViewModel::class
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_location_prompt
-    override val screenCategory: ScreenCategoryName? = null
+    override val screenName: ScreenCategoryName? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -66,7 +66,7 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
     override val layoutResId: Int
         get() = R.layout.fragment_map
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Map
 
     override fun hasTransparentStatusBar() = true

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -15,7 +15,7 @@ import com.google.android.gms.maps.model.*
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.globalLayouts
 import com.jakewharton.rxbinding2.view.visibility
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.*
 import edu.artic.db.models.*
 import edu.artic.location.LocationPromptFragment
@@ -66,8 +66,8 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
 
     override val layoutResId: Int
         get() = R.layout.fragment_map
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Map
+    override val screenName: ScreenName
+        get() = ScreenName.Map
 
     override fun hasTransparentStatusBar() = true
 

--- a/map/src/main/kotlin/edu/artic/map/MapObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapObjectDetailsFragment.kt
@@ -5,7 +5,7 @@ import android.view.View
 import com.fuzz.rx.*
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.text
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.db.models.ArticObject
 import edu.artic.image.GlideApp
 import edu.artic.media.audio.AudioPlayerService
@@ -40,8 +40,8 @@ class MapObjectDetailsFragment : BaseViewModelFragment<MapObjectDetailsViewModel
     override val overrideStatusBarColor: Boolean
         get() = false
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.OnViewDetails
+    override val screenName: ScreenName
+        get() = ScreenName.OnViewDetails
 
     private val mapObject: ArticObject by lazy { arguments!!.getParcelable<ArticObject>(ARG_MAP_OBJECT) }
     private var audioService: Subject<AudioPlayerService> = BehaviorSubject.create()

--- a/map/src/main/kotlin/edu/artic/map/MapObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapObjectDetailsFragment.kt
@@ -40,7 +40,7 @@ class MapObjectDetailsFragment : BaseViewModelFragment<MapObjectDetailsViewModel
     override val overrideStatusBarColor: Boolean
         get() = false
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.OnViewDetails
 
     private val mapObject: ArticObject by lazy { arguments!!.getParcelable<ArticObject>(ARG_MAP_OBJECT) }

--- a/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapViewModel.kt
@@ -458,7 +458,7 @@ class MapViewModel @Inject constructor(val mapMarkerConstructor: MapMarkerConstr
         shouldFollowUser = !shouldFollowUser
 
         if (shouldFollowUser) {
-            analyticsTracker.reportEvent(EventCategoryName.Location, AnalyticsAction.headingEnabled)
+            analyticsTracker.reportEvent(EventCategoryName.Location, AnalyticsAction.locationHeadingEnabled)
         }
     }
 

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
@@ -45,7 +45,7 @@ class SearchObjectDetailsFragment : BaseViewModelFragment<SearchObjectDetailsVie
     override val overrideStatusBarColor: Boolean
         get() = false
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Search
 
     private var audioService: Subject<AudioPlayerService> = BehaviorSubject.create()

--- a/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/SearchObjectDetailsFragment.kt
@@ -13,7 +13,7 @@ import com.jakewharton.rxbinding2.view.visibility
 import edu.artic.adapter.toPagerAdapter
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.db.models.ArticExhibition
 import edu.artic.db.models.ArticObject
 import edu.artic.db.models.ArticSearchArtworkObject
@@ -45,8 +45,8 @@ class SearchObjectDetailsFragment : BaseViewModelFragment<SearchObjectDetailsVie
     override val overrideStatusBarColor: Boolean
         get() = false
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Search
+    override val screenName: ScreenName
+        get() = ScreenName.Search
 
     private var audioService: Subject<AudioPlayerService> = BehaviorSubject.create()
     private val adapter = SearchedObjectsAdapter()

--- a/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import com.fuzz.rx.defaultThrottle
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.map.R
 import edu.artic.ui.BaseFragment
 import io.reactivex.rxkotlin.subscribeBy
@@ -25,7 +25,7 @@ class LeaveCurrentTourDialogFragment : BaseFragment() {
 
     override val title = R.string.noTitle
 
-    override val screenName: ScreenCategoryName?
+    override val screenName: ScreenName?
         get() = null
 
     override val layoutResId: Int = R.layout.fragment_leave_tour_dialog

--- a/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/LeaveCurrentTourDialogFragment.kt
@@ -25,7 +25,7 @@ class LeaveCurrentTourDialogFragment : BaseFragment() {
 
     override val title = R.string.noTitle
 
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = null
 
     override val layoutResId: Int = R.layout.fragment_leave_tour_dialog

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselFragment.kt
@@ -11,7 +11,7 @@ import edu.artic.adapter.itemChanges
 import edu.artic.adapter.toPagerAdapter
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.db.models.ArticObject
 import edu.artic.db.models.ArticTour
 import edu.artic.map.R
@@ -40,7 +40,7 @@ class TourCarouselFragment : BaseViewModelFragment<TourCarouselViewModel>() {
     override val layoutResId: Int
         get() = R.layout.fragment_tour_carousel
 
-    override val screenName: ScreenCategoryName?
+    override val screenName: ScreenName?
         get() = null
 
     override val overrideStatusBarColor: Boolean

--- a/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/carousel/TourCarouselFragment.kt
@@ -40,7 +40,7 @@ class TourCarouselFragment : BaseViewModelFragment<TourCarouselViewModel>() {
     override val layoutResId: Int
         get() = R.layout.fragment_tour_carousel
 
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = null
 
     override val overrideStatusBarColor: Boolean

--- a/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
@@ -13,7 +13,7 @@ import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.toPagerAdapter
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.db.INVALID_FLOOR
 import edu.artic.map.R
 import edu.artic.viewmodel.BaseViewModelFragment
@@ -38,7 +38,7 @@ class TutorialFragment : BaseViewModelFragment<TutorialViewModel>() {
     override val viewModelClass: KClass<TutorialViewModel> = TutorialViewModel::class
     override val title: Int = 0
     override val layoutResId: Int = R.layout.fragment_tutorial
-    override val screenName: ScreenCategoryName? = null
+    override val screenName: ScreenName? = null
 
     private val adapter = TutorialPopupAdapter()
 

--- a/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
@@ -38,7 +38,7 @@ class TutorialFragment : BaseViewModelFragment<TutorialViewModel>() {
     override val viewModelClass: KClass<TutorialViewModel> = TutorialViewModel::class
     override val title: Int = 0
     override val layoutResId: Int = R.layout.fragment_tutorial
-    override val screenCategory: ScreenCategoryName? = null
+    override val screenName: ScreenCategoryName? = null
 
     private val adapter = TutorialPopupAdapter()
 

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -62,7 +62,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
     override val layoutResId: Int
         get() = R.layout.fragment_audio_details
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.AudioPlayer
 
     var boundService: AudioPlayerService? = null

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -28,6 +28,7 @@ import edu.artic.db.models.ArticTour
 import edu.artic.db.models.AudioFileModel
 import edu.artic.db.models.getIntroStop
 import edu.artic.image.GlideApp
+import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
 import edu.artic.media.audio.AudioPlayerService

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -21,14 +21,13 @@ import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.itemSelections
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.*
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.filterHtmlEncodedText
 import edu.artic.db.models.ArticTour
 import edu.artic.db.models.AudioFileModel
 import edu.artic.db.models.getIntroStop
 import edu.artic.image.GlideApp
-import edu.artic.image.listenerAnimateSharedTransaction
 import edu.artic.language.LanguageAdapter
 import edu.artic.language.LanguageSelectorViewBackground
 import edu.artic.media.audio.AudioPlayerService
@@ -62,8 +61,8 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
     override val layoutResId: Int
         get() = R.layout.fragment_audio_details
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.AudioPlayer
+    override val screenName: ScreenName
+        get() = ScreenName.AudioPlayer
 
     var boundService: AudioPlayerService? = null
 

--- a/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
@@ -47,7 +47,7 @@ class NarrowAudioPlayerFragment : BaseViewModelFragment<NarrowAudioPlayerViewMod
     override val layoutResId: Int
         get() = R.layout.fragment_bottom_audio_player
 
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = null
 
     override val overrideStatusBarColor: Boolean

--- a/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
@@ -11,7 +11,7 @@ import android.view.View
 import com.fuzz.rx.bindToMain
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.visibility
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.media.audio.AudioPlayerService
 import edu.artic.navigation.NavigationConstants
@@ -47,7 +47,7 @@ class NarrowAudioPlayerFragment : BaseViewModelFragment<NarrowAudioPlayerViewMod
     override val layoutResId: Int
         get() = R.layout.fragment_bottom_audio_player
 
-    override val screenName: ScreenCategoryName?
+    override val screenName: ScreenName?
         get() = null
 
     override val overrideStatusBarColor: Boolean

--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsFragment.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsFragment.kt
@@ -1,7 +1,7 @@
 package edu.artic.search
 
 
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import kotlin.reflect.KClass
 
 
@@ -9,5 +9,5 @@ class DefaultSearchSuggestionsFragment : SearchBaseFragment<DefaultSearchSuggest
     override val viewModelClass: KClass<DefaultSearchSuggestionsViewModel>
         get() = DefaultSearchSuggestionsViewModel::class
 
-    override val screenName: ScreenCategoryName? = ScreenCategoryName.Search
+    override val screenName: ScreenName? = ScreenName.Search
 }

--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsFragment.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsFragment.kt
@@ -9,5 +9,5 @@ class DefaultSearchSuggestionsFragment : SearchBaseFragment<DefaultSearchSuggest
     override val viewModelClass: KClass<DefaultSearchSuggestionsViewModel>
         get() = DefaultSearchSuggestionsViewModel::class
 
-    override val screenCategory: ScreenCategoryName? = ScreenCategoryName.Search
+    override val screenName: ScreenCategoryName? = ScreenCategoryName.Search
 }

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -7,7 +7,7 @@ import android.support.v7.widget.GridLayoutManager
 import android.view.View
 import com.fuzz.rx.disposedBy
 import edu.artic.adapter.itemClicksWithPosition
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.artwork.ArtworkDetailFragment
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.customTab.CustomTabManager
@@ -29,7 +29,7 @@ import javax.inject.Inject
 abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewModelFragment<TViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_search_results_sub
-    override val screenName: ScreenCategoryName? = null
+    override val screenName: ScreenName? = null
 
     override val overrideStatusBarColor: Boolean = false
 

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewModelFragment<TViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_search_results_sub
-    override val screenCategory: ScreenCategoryName? = null
+    override val screenName: ScreenCategoryName? = null
 
     override val overrideStatusBarColor: Boolean = false
 

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -4,7 +4,6 @@ import com.fuzz.rx.bindTo
 import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
-import edu.artic.analytics.ScreenCategoryName
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ArticExhibition
 import edu.artic.db.models.ArticSearchArtworkObject

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -76,16 +76,16 @@ open class SearchBaseViewModel @Inject constructor(
             is SearchAmenitiesCellViewModel -> {
                 when (viewModel.type) {
                     SuggestedMapAmenities.Dining -> {
-                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowDining)
+                        analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowDining)
                     }
                     SuggestedMapAmenities.Restrooms -> {
-                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowRestrooms)
+                        analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowRestrooms)
                     }
                     SuggestedMapAmenities.GiftShop -> {
-                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowGiftShops)
+                        analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowGiftShops)
                     }
                     SuggestedMapAmenities.MembersLounge -> {
-                        analyticsTracker.reportEvent(ScreenCategoryName.Map, AnalyticsAction.mapShowMemberLounge)
+                        analyticsTracker.reportEvent(EventCategoryName.Map, AnalyticsAction.mapShowMemberLounge)
                     }
                 }
                 navigateTo.onNext(

--- a/search/src/main/java/edu/artic/search/SearchFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchFragment.kt
@@ -39,7 +39,7 @@ class SearchFragment : BaseViewModelFragment<SearchViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_search
-    override val screenCategory: ScreenCategoryName?
+    override val screenName: ScreenCategoryName?
         get() = null
 
     override fun hasTransparentStatusBar(): Boolean = false

--- a/search/src/main/java/edu/artic/search/SearchFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchFragment.kt
@@ -9,7 +9,7 @@ import com.fuzz.rx.filterFlatMap
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.afterTextChangeEvents
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.disposables.Disposable
@@ -39,7 +39,7 @@ class SearchFragment : BaseViewModelFragment<SearchViewModel>() {
     override val title = R.string.noTitle
     override val layoutResId: Int
         get() = R.layout.fragment_search
-    override val screenName: ScreenCategoryName?
+    override val screenName: ScreenName?
         get() = null
 
     override fun hasTransparentStatusBar(): Boolean = false

--- a/search/src/main/java/edu/artic/search/SearchResultsContainerFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultsContainerFragment.kt
@@ -17,7 +17,7 @@ class SearchResultsContainerFragment : BaseViewModelFragment<SearchResultsContai
     override val viewModelClass: KClass<SearchResultsContainerViewModel> = SearchResultsContainerViewModel::class
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_search_results
-    override val screenCategory: ScreenCategoryName? = ScreenCategoryName.Search
+    override val screenName: ScreenCategoryName? = ScreenCategoryName.Search
 
     override val overrideStatusBarColor: Boolean = false
 

--- a/search/src/main/java/edu/artic/search/SearchResultsContainerFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultsContainerFragment.kt
@@ -8,7 +8,7 @@ import android.support.v4.view.ViewPager
 import android.view.View
 import android.widget.TextView
 import com.fuzz.rx.disposedBy
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.viewmodel.BaseViewModelFragment
 import kotlinx.android.synthetic.main.fragment_search_results.*
 import kotlin.reflect.KClass
@@ -17,7 +17,7 @@ class SearchResultsContainerFragment : BaseViewModelFragment<SearchResultsContai
     override val viewModelClass: KClass<SearchResultsContainerViewModel> = SearchResultsContainerViewModel::class
     override val title = R.string.noTitle
     override val layoutResId: Int = R.layout.fragment_search_results
-    override val screenName: ScreenCategoryName? = ScreenCategoryName.Search
+    override val screenName: ScreenName? = ScreenName.Search
 
     override val overrideStatusBarColor: Boolean = false
 

--- a/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
+++ b/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
@@ -11,7 +11,7 @@ import com.fuzz.rx.filterFlatMap
 import com.jakewharton.rxbinding2.view.clicks
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.navigation.NavigationConstants
 import edu.artic.tours.recyclerview.AllToursItemDecoration
@@ -24,8 +24,8 @@ import kotlin.reflect.KClass
 
 class AllToursFragment : BaseViewModelFragment<AllToursViewModel>() {
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Tours
+    override val screenName: ScreenName
+        get() = ScreenName.Tours
 
     override val viewModelClass: KClass<AllToursViewModel>
         get() = AllToursViewModel::class

--- a/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
+++ b/tours/src/main/kotlin/edu/artic/tours/AllToursFragment.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 
 class AllToursFragment : BaseViewModelFragment<AllToursViewModel>() {
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Tours
 
     override val viewModelClass: KClass<AllToursViewModel>

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -15,7 +15,7 @@ import androidx.navigation.Navigation
 import com.fuzz.rx.DisposeBag
 import dagger.android.support.AndroidSupportInjection
 import edu.artic.analytics.AnalyticsTracker
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.getThemeColors
 import edu.artic.base.utils.setWindowFlag
 import javax.inject.Inject
@@ -68,7 +68,7 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
     @get:LayoutRes
     protected abstract val layoutResId: Int
 
-    abstract val screenName: ScreenCategoryName?
+    abstract val screenName: ScreenName?
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -42,6 +42,7 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
      * C.f. [updateToolbar]
      */
     fun requestTitleUpdate(proposedTitle: String) {
+
         baseActivity.runOnUiThread {
             this.requestedTitle = proposedTitle
             /**
@@ -67,7 +68,7 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
     @get:LayoutRes
     protected abstract val layoutResId: Int
 
-    abstract val screenCategory: ScreenCategoryName?
+    abstract val screenName: ScreenCategoryName?
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
@@ -99,7 +100,7 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
 
     override fun onStart() {
         super.onStart()
-        screenCategory?.let {
+        screenName?.let {
             analyticsTracker.reportScreenView(it)
         }
     }

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -13,7 +13,7 @@ import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
-import edu.artic.analytics.ScreenCategoryName
+import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.events.EventDetailFragment
 import edu.artic.exhibitions.ExhibitionDetailFragment
@@ -30,8 +30,8 @@ import kotlin.reflect.KClass
 
 class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
 
-    override val screenName: ScreenCategoryName
-        get() = ScreenCategoryName.Home
+    override val screenName: ScreenName
+        get() = ScreenName.Home
 
     override val title = R.string.welcome
 

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.KClass
 
 class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
 
-    override val screenCategory: ScreenCategoryName
+    override val screenName: ScreenCategoryName
         get() = ScreenCategoryName.Home
 
     override val title = R.string.welcome


### PR DESCRIPTION
`ScreenCategoryName` was used as event category instead of using `EventCategoryName` for analytics events. Changes in this pull req will fix those issues.
