### PR TITLE
Prevent crashes caused by misconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,28 @@ The project maintains an overview of the more interesting modules in
 
 ## How to Build
 
-This project should build perfectly as is using the standard build commands, but is unlikely to 
-function properly without key attributes defined in the build process. 
+This project should build perfectly as is using the standard build
+commands, but is unlikely to function properly without key attributes
+defined in the build process.
 
 Details below:
 
-In .circleci/ you will find a `config.yml` which controls our circle ci build process.
+In .circleci/ you will find a `config.yml` which controls our circle ci
+build process.
 
 ```aidl
 ./gradlew assembleDebug assembleRelease
 ```
 
-There is one hidden aspect of the build process not available for public consumption which
-is the keystore and keys used in the app. Due to infrastructure difference between our public
-build server and release of the app we handle injecting these variables into our build process
-by using the method `envVariable(key, isRelease)` within the gradle files.
+There is one hidden aspect of the build process not available for public
+consumption which is the keystore and keys used in the app. Due to
+infrastructure difference between our public build server and release of
+the app we handle injecting these variables into our build process by
+using the method `envVariable(key, isRelease)` within the gradle files.
 
-This function loads all the appropriate values for the keys from one of three places depending on 
-where you define them. You can see the full set of values needed in `env.sample` 
+This function loads all the appropriate values for the keys from one of
+three places depending on where you define them. You can see the full
+set of values needed in `env.sample`
 
 The values get loaded in the following order:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ build process.
 ./gradlew assembleDebug assembleRelease
 ```
 
+### Environment Variables
+
 There is one hidden aspect of the build process not available for public
 consumption which is the keystore and keys used in the app. Due to
 infrastructure difference between our public build server and release of
@@ -94,3 +96,20 @@ keystore_password=
 keystore_alias=
 keystore_alias_password=
 ```
+
+### Bundling App Data as JSON (_debug builds only_)
+
+As a special case, if `blob_url` is not defined or is not a string
+starting with `https://`, the app can run in a reduced capacity. This
+feature is intended for `debug` configurations only and thus does
+nothing in release builds.
+
+If a JSON file
+1. was present in either `db/src/main/assets/` or `db/src/debug/assets/`
+at build time
+2. had the name `app-data-v2.json`
+and
+3. conforms to the expected format of `ArticAppData`
+
+then the content of that JSON file will overwrite whatever content is
+currently in the database.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ using the method `envVariable(key, isRelease)` within the gradle files.
 
 This function loads all the appropriate values for the keys from one of
 three places depending on where you define them. You can see the full
-set of values needed in `env.sample`
+set of values needed in `env.sample`.
 
-The values get loaded in the following order:
+These values are loaded from one of the following sources, listed here
+in decreasing order of priority:
 
-* release.env or dev.env (Deployments use this model)
+* release.env or debug.env (Deployments use this model)
 * local.properties (Development uses this model primarily)
 * environment variables (Circle CI, uses this model)
 

--- a/db/src/main/kotlin/edu/artic/db/ApiModule.kt
+++ b/db/src/main/kotlin/edu/artic/db/ApiModule.kt
@@ -150,7 +150,7 @@ abstract class ApiModule {
                 dataObjectDao: ArticDataObjectDao
         ): AppDataServiceProvider {
             return if (retrofit == null) {
-                LocalAppDataServiceProvider(moshi, context, dataObjectDao)
+                LocalAppDataServiceProvider("app-data-v2.json", moshi, context, dataObjectDao)
             } else {
                 RetrofitAppDataServiceProvider(retrofit, progressEventBus, dataObjectDao)
             }

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -6,6 +6,7 @@ import edu.artic.db.daos.*
 import edu.artic.db.models.*
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
+import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -119,6 +120,7 @@ class AppDataManager @Inject constructor(
      */
     fun getBlob(): Observable<ProgressDataState> {
         return serviceProvider.getBlobHeaders()
+                .observeOn(Schedulers.io())
                 .flatMap { headers ->
                     // First, verify that we actually _have_ what we need. This is quick.
                     enforceSanityCheck()

--- a/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
@@ -1,0 +1,95 @@
+package edu.artic.db
+
+import android.content.Context
+import com.fuzz.rx.bindTo
+import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.models.ArticAppData
+import edu.artic.db.models.ArticDataObject
+import io.reactivex.Observable
+import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.Subject
+import org.threeten.bp.*
+import org.threeten.bp.format.DateTimeFormatter
+
+/**
+ * Implementation of [AppDataServiceProvider] that derives [ArticAppData] from local files.
+ *
+ * It will always return empty lists when asked for [events][getEvents] or
+ * [exhibitions][getExhibitions].
+ */
+class LocalAppDataServiceProvider(
+        private val context: Context,
+        dataObjectDao: ArticDataObjectDao
+) : AppDataServiceProvider {
+
+    private val dataObject: Subject<ArticDataObject> = BehaviorSubject.create()
+
+    /**
+     * The returned object can parse and print timestamps in accordance with
+     * [https://tools.ietf.org/html/rfc7232#section-2.2].
+     *
+     * Sample format: `Tue, 15 Nov 1994 12:45:26 GMT`
+     */
+    private val rfc7232Formatter: DateTimeFormatter
+        get() {
+            // TODO: use correct format
+            return DateTimeFormatter.ISO_DATE_TIME
+        }
+
+    init {
+        dataObjectDao
+                .getDataObject()
+                .bindTo(dataObject)
+    }
+
+    override fun getBlobHeaders(): Observable<Map<String, List<String>>> {
+        val museumZone = ZoneId.of("America/Chicago")
+
+        val lastModified: ZonedDateTime = ZonedDateTime.of(
+                LocalDate.now(museumZone),
+                LocalTime.MIN,
+                museumZone
+        )
+
+        return Observable.just(
+                mapOf(
+                        "last_modified" to listOf(rfc7232Formatter.format(lastModified))
+                )
+        )
+    }
+
+    override fun getBlob(): Observable<ProgressDataState> {
+        return Observable.create { observer ->
+            context.assets.open("app-data-v2.json").use {
+
+                // TODO: Read in from JSON file
+
+                return@create
+            }
+        }
+    }
+
+    override fun getExhibitions(): Observable<ProgressDataState> {
+        return Observable.create { observer ->
+            dataObject.subscribeBy(
+                    onError = { observer.onError(it) },
+                    onNext = { _ ->
+                        // TODO: Return empty result
+                        return@subscribeBy
+                    })
+        }
+    }
+
+    override fun getEvents(): Observable<ProgressDataState> {
+        return Observable.create { observer ->
+            dataObject.subscribeBy(
+                    onError = { observer.onError(it) },
+                    onNext = { _ ->
+                        // TODO: Return empty result
+                        return@subscribeBy
+                    })
+        }
+    }
+
+}

--- a/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
@@ -104,7 +104,7 @@ class LocalAppDataServiceProvider(
     override fun getBlob(): Observable<ProgressDataState> {
         return Observable.create { observer ->
 
-            if (assetName == null) {
+            if (assetName == null || !BuildConfig.DEBUG) {
                 observer.onError(NoAppDataException(noDataErrorMessage))
                 return@create
             }

--- a/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/LocalAppDataServiceProvider.kt
@@ -14,6 +14,10 @@ import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import org.threeten.bp.*
 import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.format.DateTimeFormatterBuilder
+import org.threeten.bp.format.TextStyle
+import org.threeten.bp.temporal.ChronoField
+import java.util.Locale
 
 /**
  * Implementation of [AppDataServiceProvider] that derives [ArticAppData] from local files.
@@ -38,8 +42,19 @@ class LocalAppDataServiceProvider(
      */
     private val rfc7232Formatter: DateTimeFormatter
         get() {
-            // TODO: use correct format
-            return DateTimeFormatter.ISO_DATE_TIME
+            return DateTimeFormatterBuilder()
+                    .appendText(ChronoField.DAY_OF_WEEK, TextStyle.SHORT)
+                    .appendLiteral(", ")
+                    .appendValue(ChronoField.DAY_OF_MONTH, 2)
+                    .appendLiteral(' ')
+                    .appendText(ChronoField.MONTH_OF_YEAR, TextStyle.SHORT)
+                    .appendLiteral(' ')
+                    .appendValue(ChronoField.YEAR, 4)
+                    .appendLiteral(' ')
+                    .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                    .appendLiteral(' ')
+                    .appendZoneText(TextStyle.SHORT)
+                    .toFormatter(Locale.ENGLISH)
         }
 
     init {

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -10,7 +10,6 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import retrofit2.Retrofit
-import javax.inject.Named
 
 /**
  * Reference implementation of [AppDataServiceProvider] for the Art Institute of Chicago.
@@ -20,7 +19,7 @@ import javax.inject.Named
  * are expected to run in the [io.reactivex.schedulers.Schedulers.io] thread-pool.
  */
 class RetrofitAppDataServiceProvider(
-        @Named(ApiModule.RETROFIT_BLOB_API) retrofit: Retrofit,
+        retrofit: Retrofit,
         private val progressEventBus: ProgressEventBus,
         dataObjectDao: ArticDataObjectDao
 ) : AppDataServiceProvider {

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -7,6 +7,7 @@ import edu.artic.db.models.ArticDataObject
 import edu.artic.db.progress.ProgressEventBus
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import retrofit2.Retrofit
@@ -34,6 +35,7 @@ class RetrofitAppDataServiceProvider(
     init {
         dataObjectDao
                 .getDataObject()
+                .observeOn(Schedulers.io())
                 .bindTo(dataObject)
     }
 

--- a/search/src/main/java/edu/artic/search/SearchModule.kt
+++ b/search/src/main/java/edu/artic/search/SearchModule.kt
@@ -104,8 +104,14 @@ abstract class SearchModule {
         @Provides
         @Singleton
         fun provideSearchService(
-                @Named(ApiModule.RETROFIT_BLOB_API) retrofit: Retrofit,
+                @Named(ApiModule.RETROFIT_BLOB_API) retrofit: Retrofit?,
                 dataObjectDao: ArticDataObjectDao
-        ): SearchServiceProvider = RetrofitSearchServiceProvider(retrofit, dataObjectDao)
+        ): SearchServiceProvider {
+            return if (retrofit == null) {
+                NoSearchResultsServiceProvider
+            } else {
+                RetrofitSearchServiceProvider(retrofit, dataObjectDao)
+            }
+        }
     }
 }

--- a/search/src/main/java/edu/artic/search/SearchServiceProvider.kt
+++ b/search/src/main/java/edu/artic/search/SearchServiceProvider.kt
@@ -21,4 +21,25 @@ interface SearchServiceProvider {
     fun getSuggestions(searchQuery: String): Observable<Result<List<String>>>
 
     fun loadAllMatchingContent(searchQuery: String): Observable<ApiSearchResult>
+
+}
+
+/**
+ * One of the two bundled implementations of [SearchServiceProvider],
+ * along with [RetrofitSearchServiceProvider].
+ *
+ * This will always error out.
+ */
+object NoSearchResultsServiceProvider: SearchServiceProvider {
+    override fun getSuggestions(searchQuery: String): Observable<Result<List<String>>> {
+        return Observable.error(
+                SearchUnavailableError
+        )
+    }
+
+    override fun loadAllMatchingContent(searchQuery: String): Observable<ApiSearchResult> {
+        return Observable.error(
+                SearchUnavailableError
+        )
+    }
 }

--- a/search/src/main/java/edu/artic/search/SearchUnavailableError.kt
+++ b/search/src/main/java/edu/artic/search/SearchUnavailableError.kt
@@ -1,0 +1,18 @@
+package edu.artic.search
+
+/**
+ * General-purpose exception for mis-configured gradle builds.
+ *
+ * You'll see this most likely if the `build.gradle` file in the `:db`
+ * module is not able to assign a well-formed value to
+ * [edu.artic.db.BuildConfig.BLOB_URL]. This, in turn, is typically
+ * sourced from a file called `local.properties`, `debug.env`, or
+ * `release.env`.
+ *
+ * Check the top-level project README section called `How To Build`
+ * for more detailed information.
+ */
+object SearchUnavailableError : Error(
+        "Searching for Artwork, Tours, or Events will not work with this installation." +
+                " Double-check the section labeled 'How To Build' in the application README."
+)

--- a/search/src/main/java/edu/artic/search/SearchUnavailableError.kt
+++ b/search/src/main/java/edu/artic/search/SearchUnavailableError.kt
@@ -14,5 +14,9 @@ package edu.artic.search
  */
 object SearchUnavailableError : Error(
         "Searching for Artwork, Tours, or Events will not work with this installation." +
-                " Double-check the section labeled 'How To Build' in the application README."
+                if (BuildConfig.DEBUG) {
+                    " Please refer to the 'How To Build' section of the project README for details."
+                } else {
+                    " Please let us know so we can release an update that fixes the issue."
+                }
 )

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -10,7 +10,8 @@ import edu.artic.db.ProgressDataState
 import edu.artic.localization.ui.LanguageSettingsPrefManager
 import edu.artic.viewmodel.NavViewViewModel
 import edu.artic.viewmodel.Navigate
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.Subject
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -27,7 +28,7 @@ class SplashViewModel @Inject constructor(
     }
 
 
-    val percentage: PublishSubject<Float> = PublishSubject.create()
+    val percentage: Subject<Float> = BehaviorSubject.createDefault(0f)
 
     init {
         analyticsTracker.clearSession()
@@ -41,6 +42,7 @@ class SplashViewModel @Inject constructor(
                             percentage.onNext(it.progress)
                         }
                         is ProgressDataState.Done<*> -> {
+                            percentage.onNext(1.0f)
                             startVideo()
                             appDaPrefManager.downloadedNecessaryData = true
                         }


### PR DESCRIPTION
If the '.env' files are not set up right, or for that matter not defined at all, the app in its current state will crash at startup.

With these commits, a more manageable error message will be shown instead. It also adds a nice affordance to bundle a sample JSON resource with the apk, if desired.