### PR TITLE
Safeguard unit test threading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,17 @@ jobs:
   build:
     working_directory: ~/code
     docker:
+      # This image needs to match our 'target' sdk version. The 'alpha' designation
+      # _is_ kinda weird, but the images generally work just fine.
       - image: circleci/android:api-28-alpha
     environment:
+      # Gradle treats JVM_OPTS with lower precedence than JAVA_OPTS,
+      # according to https://circleci.com/blog/how-to-handle-java-oom-errors/
+      #
+      # We use a relatively low number for max memory, as that is what 
+      # https://discuss.circleci.com/t/circleci-2-0-android-with-kotlin/17531/2
+      # recommends.
+      #
       JAVA_OPTS: -Xmx1000m
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/android:api-28-alpha
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx2000m
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/android:api-28-alpha
     environment:
-      JVM_OPTS: -Xmx2000m
+      JAVA_OPTS: -Xmx1000m
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
+        classpath 'com.android.tools.build:gradle:3.4.0-alpha02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$navigation_version"
         classpath 'com.google.gms:google-services:4.1.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,16 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+#
+# Limit the number of worker processes (more or less the same as
+# how many threads to use). Default is the available CPU count.
+org.gradle.workers.max=1


### PR DESCRIPTION
Ideally, this will remove some flakiness from our tests in `AppDataManagerTest.kt`.

Said uncertainty was introduced by 9d41f309997f65.

This PR also reduces the memory usage of the JVM build process (advice derived from https://discuss.circleci.com/t/circleci-2-0-android-with-kotlin/17531/2 ) and switches the version of the Android Gradle Plugin in use to the latest stable release (v3.2.1).