### PR TITLE
Adds missing gallery label in artwork object details screen : (AIC-562)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/daos/ArticGalleryDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticGalleryDao.kt
@@ -6,6 +6,7 @@ import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
 import edu.artic.db.models.ArticGallery
 import io.reactivex.Flowable
+import io.reactivex.Single
 
 @Dao
 interface ArticGalleryDao {
@@ -15,6 +16,9 @@ interface ArticGalleryDao {
 
     @Query("select * from ArticGallery where galleryId = :id")
     fun getGalleryForGalleryIdSynchronously(id: String): ArticGallery?
+
+    @Query("select * from ArticGallery where title = :title LIMIT 1")
+    fun getGalleryByTitle(title: String): Single<ArticGallery>
 
     /**
      * Retrieve all galleries with an id in the given list.

--- a/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
@@ -119,3 +119,20 @@ data class ArticObject(
 val ArticObject.audioFile: ArticAudioFile?
     get() = this.audioCommentary.firstOrNull()?.audioFile
 
+/**
+ *  Converts ArticObject to [ArticSearchArtworkObject].
+ */
+fun ArticObject.asArticSearchArtworkObject(gallery: ArticGallery? = null) : ArticSearchArtworkObject {
+    return ArticSearchArtworkObject(
+            artworkId = this.id.toString(),
+            backingObject = this,
+            title = this.title,
+            thumbnailUrl = this.thumbUrl,
+            imageUrl = this.largeImageUrl,
+            artistTitle = this.tombstone,
+            artistDisplay = this.artistCulturePlaceDelim,
+            location = this.location,
+            floor = this.floor,
+            gallery = gallery
+    )
+}

--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
@@ -4,6 +4,7 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.daos.ArticGalleryDao
 import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.daos.ArticSearchObjectDao
 import io.reactivex.rxkotlin.Observables
@@ -19,8 +20,9 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
                                                             objectDao: ArticObjectDao,
                                                             analyticsTracker: AnalyticsTracker,
                                                             searchManager: SearchResultsManager,
-                                                            dataObjectDao: ArticDataObjectDao
-) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao) {
+                                                            dataObjectDao: ArticDataObjectDao,
+                                                            galleryDao: ArticGalleryDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao, galleryDao) {
 
     private val suggestedKeywords: Subject<List<SearchTextCellViewModel>> = BehaviorSubject.create()
     private val suggestedArtworks: Subject<List<SearchCircularCellViewModel>> = BehaviorSubject.create()

--- a/search/src/main/java/edu/artic/search/SearchArtworkViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchArtworkViewModel.kt
@@ -4,13 +4,15 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.daos.ArticGalleryDao
 import javax.inject.Inject
 
 class SearchArtworkViewModel @Inject constructor(
         searchManager: SearchResultsManager,
         analyticsTracker: AnalyticsTracker,
-        dataObjectDao: ArticDataObjectDao
-) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao) {
+        dataObjectDao: ArticDataObjectDao,
+        galleryDao: ArticGalleryDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao, galleryDao) {
 
     sealed class NavigationEndpoint
 

--- a/search/src/main/java/edu/artic/search/SearchExhibitionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchExhibitionsViewModel.kt
@@ -4,13 +4,15 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.daos.ArticGalleryDao
 import javax.inject.Inject
 
 class SearchExhibitionsViewModel @Inject constructor(
         searchManager: SearchResultsManager,
         analyticsTracker: AnalyticsTracker,
-        dataObjectDao: ArticDataObjectDao
-) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao)  {
+        dataObjectDao: ArticDataObjectDao,
+        galleryDao: ArticGalleryDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao, galleryDao)  {
 
     sealed class NavigationEndpoint
 

--- a/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
@@ -6,6 +6,7 @@ import edu.artic.analytics.AnalyticsAction
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
 import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.daos.ArticGalleryDao
 import edu.artic.db.daos.ArticObjectDao
 import edu.artic.db.daos.ArticSearchObjectDao
 import edu.artic.db.models.ArticExhibition
@@ -21,8 +22,9 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
                                                    private val searchSuggestionsDao: ArticSearchObjectDao,
                                                    private val objectDao: ArticObjectDao,
                                                    analyticsTracker: AnalyticsTracker,
-                                                   dataObjectDao: ArticDataObjectDao)
-    : SearchBaseViewModel(analyticsTracker, manager, dataObjectDao) {
+                                                   dataObjectDao: ArticDataObjectDao,
+                                                   galleryDao: ArticGalleryDao)
+    : SearchBaseViewModel(analyticsTracker, manager, dataObjectDao, galleryDao) {
 
     private val dynamicCells: Subject<List<SearchBaseCellViewModel>> = BehaviorSubject.create()
     private val suggestedArtworks: Subject<List<SearchCircularCellViewModel>> = BehaviorSubject.create()

--- a/search/src/main/java/edu/artic/search/SearchToursViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchToursViewModel.kt
@@ -4,13 +4,15 @@ import com.fuzz.rx.bindTo
 import com.fuzz.rx.disposedBy
 import edu.artic.analytics.AnalyticsTracker
 import edu.artic.db.daos.ArticDataObjectDao
+import edu.artic.db.daos.ArticGalleryDao
 import javax.inject.Inject
 
 class SearchToursViewModel @Inject constructor(
         searchManager: SearchResultsManager,
         analyticsTracker: AnalyticsTracker,
-        dataObjectDao: ArticDataObjectDao
-) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao)  {
+        dataObjectDao: ArticDataObjectDao,
+        galleryDao: ArticGalleryDao
+) : SearchBaseViewModel(analyticsTracker, searchManager, dataObjectDao, galleryDao)  {
 
     sealed class NavigationEndpoint
 


### PR DESCRIPTION
Gallery label for the searched object was missing for suggested map items because the `gallery`'s value was always passed as null when instantiating ArticSearchArtworkObject. This PR changes will fetch and assign the gallery if available. 