### PR TITLE
Allows entry of non-numeric characters in zip code field (AIC-574)

### DIFF
--- a/access_card/src/main/res/layout/layout_member_information_form.xml
+++ b/access_card/src/main/res/layout/layout_member_information_form.xml
@@ -62,7 +62,6 @@
         android:layout_marginTop="@dimen/marginOneHalf"
         android:autofillHints="postalCode"
         android:background="@color/infoInputFieldWhite"
-        android:inputType="number"
         android:padding="@dimen/marginStandard"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Basically, removes `android:inputType="number"` attribute from zip code field.