### PR TITLE
Ignore textual case on Event Details screen when comparing API text (AIC-565)

### DIFF
--- a/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/events/EventDetailFragment.kt
@@ -25,6 +25,7 @@ import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.rxkotlin.Observables
 import kotlinx.android.synthetic.main.fragment_event_details.*
+import java.util.Locale
 import kotlin.reflect.KClass
 
 class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
@@ -125,9 +126,9 @@ class EventDetailFragment : BaseViewModelFragment<EventDetailViewModel>() {
 
         viewModel.eventButtonText
                 .map {
-                    when(it) {
-                        "Buy Tickets" -> getString(R.string.buyTickets)
-                        "Register" -> getString(R.string.register)
+                    when(it.toLowerCase(Locale.ROOT)) {
+                        "buy tickets" -> getString(R.string.buyTickets)
+                        "register" -> getString(R.string.register)
                         else -> it
                     }
                 }


### PR DESCRIPTION
Self-explanatory, really.