### PR TITLE
Prevent early access to map elements (AIC-544)

### DIFF
--- a/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
+++ b/location_ui/src/main/java/edu/artic/location/LocationPromptFragment.kt
@@ -1,11 +1,15 @@
 package edu.artic.location
 
+import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
 import edu.artic.analytics.ScreenName
 import edu.artic.location_ui.R
+import edu.artic.map.overrideMapAccess
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import kotlinx.android.synthetic.main.fragment_location_prompt.*
@@ -52,5 +56,13 @@ class LocationPromptFragment : BaseViewModelFragment<LocationPromptViewModel>() 
                 .subscribe {
                     activity?.onBackPressed()
                 }.disposedBy(navigationDisposeBag)
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        if (context is Activity) {
+            // We expect this will be reset to 'auto' by 'TutorialFragment'.
+            overrideMapAccess(context, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+        }
     }
 }

--- a/location_ui/src/main/java/edu/artic/map/MapFragmentExtension.kt
+++ b/location_ui/src/main/java/edu/artic/map/MapFragmentExtension.kt
@@ -1,0 +1,18 @@
+package edu.artic.map
+
+import android.app.Activity
+import android.view.ViewGroup
+import edu.artic.location_ui.R
+
+/**
+ * Quick setter for the first `mapFragmentRoot` found in the given Activity's layout (if any).
+ *
+ * Use this to adjust [ViewGroup.setImportantForAccessibility].
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+fun overrideMapAccess(act: Activity?, mode: Int) {
+    val root = act?.findViewById<ViewGroup?>(R.id.mapFragmentRoot)
+
+    root?.importantForAccessibility = mode
+}

--- a/location_ui/src/main/res/values/ids.xml
+++ b/location_ui/src/main/res/values/ids.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Use this in at the top of the layout for whichever MapFragment is in use. -->
+    <item name="mapFragmentRoot" type="id"/>
+</resources>

--- a/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/tutorial/TutorialFragment.kt
@@ -1,5 +1,7 @@
 package edu.artic.map.tutorial
 
+import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.support.v4.view.ViewPager
 import android.view.MotionEvent
@@ -16,6 +18,7 @@ import edu.artic.adapter.toPagerAdapter
 import edu.artic.analytics.ScreenName
 import edu.artic.db.INVALID_FLOOR
 import edu.artic.map.R
+import edu.artic.map.overrideMapAccess
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -163,6 +166,18 @@ class TutorialFragment : BaseViewModelFragment<TutorialViewModel>() {
                 .subscribe {
                     activity?.onBackPressed()
                 }.disposedBy(navigationDisposeBag)
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        if (context is Activity) {
+            overrideMapAccess(context, View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        overrideMapAccess(activity, View.IMPORTANT_FOR_ACCESSIBILITY_AUTO)
     }
 
     companion object {

--- a/map/src/main/res/layout/fragment_map.xml
+++ b/map/src/main/res/layout/fragment_map.xml
@@ -2,6 +2,7 @@
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@id/mapFragmentRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true">


### PR DESCRIPTION
When an accessibility service is active, the Map section's 'share location' and tutorial fragments are a little hard to work with. This change prevents any interaction with the `GoogleMap` while either of those are on-screen.

This does not include any changes to the 'Leave Tour' functionality.