### PR TITLE
Map artwork ordering (AIC-586)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticObjectDao.kt
@@ -55,7 +55,8 @@ interface ArticObjectDao {
     @Query("select * from ArticObject where galleryLocation in (:galleryTitle)")
     fun getObjectsInGallery(galleryTitle: String): List<ArticObject>
 
-    @Query(value = "select * from ArticObject where nid in (:ids)")
+    /** Database does not preserve the order of ids.**/
+    @Query(value = "select * from ArticObject where nid in (:ids) order by nid")
     fun getObjectsByIdList(ids: List<String>): Flowable<List<ArticObject>>
 
     @Query("select * from ArticObject where floor = :floor")

--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
@@ -48,12 +48,7 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
                 .bindTo(suggestedKeywords)
                 .disposedBy(disposeBag)
 
-        searchSuggestionsDao.getDataObject()
-                .toObservable()
-                .map { suggestedSearchOptions -> suggestedSearchOptions.searchObjects }
-                .flatMap { idsList ->
-                    objectDao.getObjectsByIdList(idsList).toObservable()
-                }
+        getSuggestedArtworks(searchSuggestionsDao, objectDao)
                 .map { objects ->
                     objects.map { artwork ->
                         SearchCircularCellViewModel(artwork)

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -8,6 +8,8 @@ import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.EventCategoryName
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.daos.ArticGalleryDao
+import edu.artic.db.daos.ArticObjectDao
+import edu.artic.db.daos.ArticSearchObjectDao
 import edu.artic.db.models.*
 import edu.artic.viewmodel.NavViewViewModel
 import edu.artic.viewmodel.Navigate
@@ -173,5 +175,37 @@ open class SearchBaseViewModel @Inject constructor(
 
     open fun onClickSeeAll(header: Header) {
 
+    }
+
+    /**
+     * Returns suggested artworks.
+     */
+    protected fun getSuggestedArtworks(searchSuggestionsDao: ArticSearchObjectDao,
+                                       objectDao: ArticObjectDao
+    ): Observable<MutableList<ArticObject>> {
+        return searchSuggestionsDao.getDataObject()
+                .toObservable()
+                .map { suggestedSearchOptions -> suggestedSearchOptions.searchObjects }
+                .flatMap { idsList ->
+                    /**
+                     * Database does not preserve the order of ids.
+                     */
+                    objectDao.getObjectsByIdList(idsList)
+                            .toObservable()
+                            .map { unSortedObjects ->
+                                /**
+                                 * Sorting the objects based on idsList
+                                 */
+                                val sortedObjects = mutableListOf<ArticObject>()
+                                for (id in idsList) {
+                                    unSortedObjects
+                                            .find { it.nid == id }
+                                            ?.also {
+                                                sortedObjects.add(it)
+                                            }
+                                }
+                                sortedObjects
+                            }
+                }
     }
 }

--- a/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseViewModel.kt
@@ -178,11 +178,11 @@ open class SearchBaseViewModel @Inject constructor(
     }
 
     /**
-     * Returns suggested artworks.
+     * Returns suggested artworks preserving the CMS order.
      */
     protected fun getSuggestedArtworks(searchSuggestionsDao: ArticSearchObjectDao,
                                        objectDao: ArticObjectDao
-    ): Observable<MutableList<ArticObject>> {
+    ): Observable<List<ArticObject>> {
         return searchSuggestionsDao.getDataObject()
                 .toObservable()
                 .map { suggestedSearchOptions -> suggestedSearchOptions.searchObjects }
@@ -196,13 +196,8 @@ open class SearchBaseViewModel @Inject constructor(
                                 /**
                                  * Sorting the objects based on idsList
                                  */
-                                val sortedObjects = mutableListOf<ArticObject>()
-                                for (id in idsList) {
-                                    unSortedObjects
-                                            .find { it.nid == id }
-                                            ?.also {
-                                                sortedObjects.add(it)
-                                            }
+                                val sortedObjects: List<ArticObject> = idsList.mapNotNull { id ->
+                                    unSortedObjects.find { it.nid == id }
                                 }
                                 sortedObjects
                             }

--- a/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
@@ -64,12 +64,7 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
     }
 
     private fun setupOnMapSuggestionsBind() {
-        searchSuggestionsDao.getDataObject()
-                .toObservable()
-                .map { suggestedSearchOptions -> suggestedSearchOptions.searchObjects }
-                .flatMap { idsList ->
-                    objectDao.getObjectsByIdList(idsList).toObservable()
-                }
+        getSuggestedArtworks(searchSuggestionsDao, objectDao)
                 .map { objects ->
                     objects.map {
                         SearchCircularCellViewModel(it)


### PR DESCRIPTION
We were expecting database would preserve the order of ids for the following sql query.

`select * from ArticObject where nid in (:ids)`

Database does not preserve the order of ids given in`IN` clause.
This PR fixes it by sorting the database result based on the input `idList`