### PR TITLE
Preserve the order of tours on `All Tours` screen (AIC-587)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/daos/ArticTourDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticTourDao.kt
@@ -22,6 +22,9 @@ interface ArticTourDao {
     @Query("select * from ArticTour limit 6")
     fun getTourSummary(): Flowable<List<ArticTour>>
 
+    @Query("select * from ArticTour")
+    fun getAllTours() : Flowable<List<ArticTour>>
+
     @Query("select * from ArticTour order by title")
     fun getTours() : Flowable<List<ArticTour>>
 

--- a/tours/src/main/kotlin/edu/artic/tours/AllToursViewModel.kt
+++ b/tours/src/main/kotlin/edu/artic/tours/AllToursViewModel.kt
@@ -32,7 +32,7 @@ class AllToursViewModel @Inject constructor(
     val intro: Subject<String> = BehaviorSubject.createDefault("")
 
     init {
-        toursDao.getTours()
+        toursDao.getAllTours()
                 .map { list ->
                     val viewModelList = ArrayList<AllToursCellViewModel>()
                     list.forEach { tour ->


### PR DESCRIPTION
Instead of sorting tour by its title, this PR preserves the order of tours in CMS. 