### PR TITLE
Membership backstack adjustments (AIC-580)

### DIFF
--- a/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
+++ b/access_card/src/main/java/edu/artic/accesscard/AccessMemberCardFragment.kt
@@ -217,6 +217,22 @@ class AccessMemberCardFragment : BaseViewModelFragment<AccessMemberCardViewModel
         animateToolbarColor()
     }
 
+    override fun onBackPressed(): Boolean {
+        val args = arguments
+        val v = view
+        val argSelfImportant = resources.getString(R.string.argSelfImportant)
+
+        return if (v != null && args?.getBoolean(argSelfImportant) == true) {
+            // By removing this fragment you remove the entire activity.
+            v.post {
+                requireActivity().finish()
+            }
+            true
+        } else {
+            super.onBackPressed()
+        }
+    }
+
     /**
      * Animates the color of toolbar and StatusBar.
      */

--- a/access_card/src/main/res/values/strings.xml
+++ b/access_card/src/main/res/values/strings.xml
@@ -10,4 +10,7 @@
     <string name="expires">Expires: %s</string>
     <string name="zipCodeHint">Enter your home zip code…</string>
     <string name="memberIdHint">Enter your Member ID…</string>
+
+    <string name="argSelfImportant" translatable="false">edu.artic.accesscard:selfImportant</string>
+
 </resources>

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -96,21 +96,19 @@ class InfoActivity : BaseActivity() {
                 } else {
                     val currentDestination = navController
                             .currentDestination
-                            ?.label
-                            ?.toString()
 
                     /**
                      * Go to access member card iff current destination's label is not
                      * [R.string.accessMemberCardLabel] (that's the Label for
                      * [edu.artic.accesscard.AccessMemberCardFragment]).
                      */
-                    if (currentDestination != resources.getString(R.string.accessMemberCardLabel)) {
+                    if (currentDestination?.id != R.id.accessMemberCardFragment) {
 
                         /**
                          * If the active fragment is not the start_destination navController can't find
                          * accessMemberCardLabel.
                          */
-                        if (currentDestination != resources.getString(R.string.fragmentInformationLabel)) {
+                        if (currentDestination?.id != R.id.informationFragment) {
                             navController.navigateUp()
                         }
 

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -2,6 +2,7 @@ package edu.artic.info
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.navigation.fragment.FragmentNavigator
 import edu.artic.accesscard.AccessMemberCardFragment
 import edu.artic.base.utils.disableShiftMode
 import edu.artic.location.LocationService
@@ -10,6 +11,7 @@ import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.linkHome
 import edu.artic.ui.BaseActivity
+import edu.artic.ui.findFragmentInHierarchy
 import edu.artic.ui.findNavController
 import kotlinx.android.synthetic.main.activity_info.*
 import timber.log.Timber
@@ -86,7 +88,9 @@ class InfoActivity : BaseActivity() {
         when (intent.data?.toString()?.replace("artic://", "")) {
             NavigationConstants.INFO_MEMBER_CARD -> {
 
-                val navController = supportFragmentManager.findNavController()
+                val fm = supportFragmentManager
+
+                val navController = fm.findNavController()
 
                 // There is only value in continuing if we have a navController to use
 
@@ -118,6 +122,14 @@ class InfoActivity : BaseActivity() {
                         navController.navigate(R.id.goToAccessMemberCard, Bundle().apply {
                             putBoolean(argSelfImportant, true)
                         })
+                    } else if (currentDestination is FragmentNavigator.Destination) {
+
+                        /**
+                         * Ensure that the associated fragment will dismiss the activity when removed
+                         */
+                        findFragmentInHierarchy<AccessMemberCardFragment>(fm, R.id.container)?.let {
+                            it.arguments?.putBoolean(argSelfImportant, true)
+                        }
                     }
                 }
             }

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -2,6 +2,7 @@ package edu.artic.info
 
 import android.content.Intent
 import android.os.Bundle
+import edu.artic.accesscard.AccessMemberCardFragment
 import edu.artic.base.utils.disableShiftMode
 import edu.artic.location.LocationService
 import edu.artic.location.LocationServiceImpl
@@ -36,7 +37,7 @@ import javax.inject.Inject
  * ## `InfoLocationSettingsFragment`
  * * In `:location_ui` module
  * * Grant or revoke location permissions
- * ## [AccessMemberCardFragment][edu.artic.accesscard.AccessMemberCardFragment]
+ * ## [AccessMemberCardFragment]
  * * In `:access_card` module
  * * Displays card metadata (if signed in)
  * * Displays sign-in form (if _not_ signed in)
@@ -97,10 +98,12 @@ class InfoActivity : BaseActivity() {
                     val currentDestination = navController
                             .currentDestination
 
+                    val argSelfImportant = getString(R.string.argSelfImportant)
+
                     /**
                      * Go to access member card iff current destination's label is not
                      * [R.string.accessMemberCardLabel] (that's the Label for
-                     * [edu.artic.accesscard.AccessMemberCardFragment]).
+                     * [AccessMemberCardFragment]).
                      */
                     if (currentDestination?.id != R.id.accessMemberCardFragment) {
 
@@ -112,7 +115,9 @@ class InfoActivity : BaseActivity() {
                             navController.navigateUp()
                         }
 
-                        navController.navigate(R.id.goToAccessMemberCard)
+                        navController.navigate(R.id.goToAccessMemberCard, Bundle().apply {
+                            putBoolean(argSelfImportant, true)
+                        })
                     }
                 }
             }

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -64,7 +64,7 @@ class InfoActivity : BaseActivity() {
                     }
                 } else {
                     val currentDestination = navController
-                            ?.currentDestination
+                            .currentDestination
                             ?.label
                             ?.toString()
 
@@ -79,10 +79,10 @@ class InfoActivity : BaseActivity() {
                          * accessMemberCardLabel.
                          */
                         if (currentDestination != resources.getString(R.string.fragmentInformationLabel)) {
-                            navController?.navigateUp()
+                            navController.navigateUp()
                         }
 
-                        navController?.navigate(R.id.goToAccessMemberCard)
+                        navController.navigate(R.id.goToAccessMemberCard)
                     }
                 }
             }

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -14,6 +14,37 @@ import kotlinx.android.synthetic.main.activity_info.*
 import timber.log.Timber
 import javax.inject.Inject
 
+/**
+ * # One of the four primary sections of the app.
+ *
+ * This Activity always hosts one full-size fragment, which must be one of
+ * the following:
+ * ## [InformationFragment] (default)
+ * * In `:info` module
+ * * Mostly just links to switch to one of the other Fragments
+ * * Includes version code, credits, link to sign up for membership, etc.
+ * ## [MuseumInformationFragment]
+ * * In `:info` module
+ * * Museum hours
+ * * Museum location
+ * * Contact info
+ * * Link to buy tickets
+ * ## [LanguageSettingsFragment][edu.artic.localization.ui.LanguageSettingsFragment]
+ * * In `:localization_ui` module
+ * * Change default application language
+ * * Disclaimer about untranslated content
+ * ## `InfoLocationSettingsFragment`
+ * * In `:location_ui` module
+ * * Grant or revoke location permissions
+ * ## [AccessMemberCardFragment][edu.artic.accesscard.AccessMemberCardFragment]
+ * * In `:access_card` module
+ * * Displays card metadata (if signed in)
+ * * Displays sign-in form (if _not_ signed in)
+ *
+ * As a primary section, this class always contains a
+ * [NarrowAudioPlayerFragment][edu.artic.media.ui.NarrowAudioPlayerFragment]
+ * and a search icon.
+ */
 class InfoActivity : BaseActivity() {
 
     /**
@@ -69,8 +100,9 @@ class InfoActivity : BaseActivity() {
                             ?.toString()
 
                     /**
-                     * Go to access member card iff current destination's label is not [R.string.accessMemberCardLabel].
-                     * Label for [AccessMemberCardFragment] is [R.string.accessMemberCardLabel].
+                     * Go to access member card iff current destination's label is not
+                     * [R.string.accessMemberCardLabel] (that's the Label for
+                     * [edu.artic.accesscard.AccessMemberCardFragment]).
                      */
                     if (currentDestination != resources.getString(R.string.accessMemberCardLabel)) {
 

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -2,7 +2,6 @@ package edu.artic.info
 
 import android.content.Intent
 import android.os.Bundle
-import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.disableShiftMode
 import edu.artic.location.LocationService
 import edu.artic.location.LocationServiceImpl
@@ -12,6 +11,7 @@ import edu.artic.navigation.linkHome
 import edu.artic.ui.BaseActivity
 import edu.artic.ui.findNavController
 import kotlinx.android.synthetic.main.activity_info.*
+import timber.log.Timber
 import javax.inject.Inject
 
 class InfoActivity : BaseActivity() {
@@ -56,26 +56,34 @@ class InfoActivity : BaseActivity() {
 
                 val navController = supportFragmentManager.findNavController()
 
-                val currentDestination = navController
-                        ?.currentDestination
-                        ?.label
-                        ?.toString()
+                // There is only value in continuing if we have a navController to use
 
-                /**
-                 * Go to access member card iff current destination's label is not [R.string.accessMemberCardLabel].
-                 * Label for [AccessMemberCardFragment] is [R.string.accessMemberCardLabel].
-                 */
-                if (currentDestination != resources.getString(R.string.accessMemberCardLabel)) {
+                if (navController == null) {
+                    if (BuildConfig.DEBUG) {
+                        Timber.w("Info screen was asked to display card, but no navigation host could be found to perform that task.")
+                    }
+                } else {
+                    val currentDestination = navController
+                            ?.currentDestination
+                            ?.label
+                            ?.toString()
 
                     /**
-                     * If the active fragment is not the start_destination navController can't find
-                     * accessMemberCardLabel.
+                     * Go to access member card iff current destination's label is not [R.string.accessMemberCardLabel].
+                     * Label for [AccessMemberCardFragment] is [R.string.accessMemberCardLabel].
                      */
-                    if (currentDestination != resources.getString(R.string.fragmentInformationLabel)) {
-                        navController?.navigateUp()
-                    }
+                    if (currentDestination != resources.getString(R.string.accessMemberCardLabel)) {
 
-                    navController?.navigate(R.id.goToAccessMemberCard)
+                        /**
+                         * If the active fragment is not the start_destination navController can't find
+                         * accessMemberCardLabel.
+                         */
+                        if (currentDestination != resources.getString(R.string.fragmentInformationLabel)) {
+                            navController?.navigateUp()
+                        }
+
+                        navController?.navigate(R.id.goToAccessMemberCard)
+                    }
                 }
             }
 

--- a/info/src/main/res/navigation/info_navigation_graph.xml
+++ b/info/src/main/res/navigation/info_navigation_graph.xml
@@ -39,6 +39,7 @@
         android:name="edu.artic.accesscard.AccessMemberCardFragment"
         android:label="@string/accessMemberCardLabel"
         tools:layout="@layout/fragment_validate_member_information">
+        <argument android:name="@string/argSelfImportant" android:defaultValue="false"/>
         <deepLink app:uri="artic://edu.artic.info/accessMemberCard" />
     </fragment>
 


### PR DESCRIPTION
This PR ensures that the link from the 'home' section to the member card screen may always be reversed with a single operation. When testing, make sure to consider situations where the 'info' section is already showing the member card and thus does not (at first glance) need to navigate anywhere.