### PR TITLE
Correct the panning behavior of the map when selecting tour stops (AIC-585, AIC-579)

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/models/ArticTour.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticTour.kt
@@ -164,5 +164,5 @@ fun ArticTour.getIntroStop(): ArticTour.TourStop {
 }
 
 fun ArticTour.TourStop.isIntroStop(): Boolean {
-    return this.objectId === INTRO_TOUR_STOP_OBJECT_ID
+    return this.objectId == INTRO_TOUR_STOP_OBJECT_ID
 }

--- a/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
@@ -13,6 +13,7 @@ data class MapChangeEvent(val focus: MapFocus, val floor: Int, val displayMode: 
 typealias ZoomLevel = Float
 
 const val ZOOM_LANDMARK: ZoomLevel = 17.5f
+const val ZOOM_INITIAL: ZoomLevel = 17.6f;
 const val ZOOM_DEPARTMENTS: ZoomLevel = 18.0f
 const val ZOOM_DEPARTMENT_AND_SPACES: ZoomLevel = 19.0f
 const val ZOOM_INDIVIDUAL: ZoomLevel = 20.3f

--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -44,7 +44,6 @@ import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.fragment_map.*
-import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
 /**
@@ -349,10 +348,10 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
                         )
                     } else {
                         // Make sure we can see all of the specified positions
-                        val lanLngBounds = LatLngBounds.builder().includeAll(bounds).build()
+                        val aoiBounds = LatLngBounds.builder().includeAll(bounds).build()
                         map.animateCamera(
                                 CameraUpdateFactory.newLatLngZoom(
-                                        lanLngBounds.center,
+                                        aoiBounds.center,
                                         Math.max(ZOOM_INDIVIDUAL, map.cameraPosition.zoom)
                                 )
                         )

--- a/map/src/main/kotlin/edu/artic/map/MapObjects.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapObjects.kt
@@ -17,5 +17,6 @@ internal fun initialMapCameraPosition(): CameraUpdate {
                     .target(centerOfMuseumOnMap)
                     .bearing(88.725f)
                     .tilt(60f)
+                    .zoom(ZOOM_INITIAL)
                     .build())
 }


### PR DESCRIPTION
This PR also, fix a bug where the intro tour stop isn't animated to just the selected stops.

Additionally we add an initial zoom that is slightly closer so that the departments are already loaded on the map and matching iOS