### PR TITLE
Update gradle dependencies for October 2018

### DIFF
--- a/access_card/build.gradle
+++ b/access_card/build.gradle
@@ -9,14 +9,14 @@ dependencies {
 
     api libs.design_support
     implementation libs.glide
-    implementation project(':membership')
     implementation project(':base')
-    implementation project(':ui')
-    implementation project(':viewmodel')
-    implementation project(':navigation')
-    implementation project(':search')
     implementation project(':db')
     implementation project(':localization')
+    implementation project(':membership')
+    implementation project(':navigation')
+    implementation project(':search')
+    implementation project(':ui')
+    implementation project(':viewmodel')
     implementation libs.constraint_layout
     implementation libs.rx_helpers
     implementation libs.rx_kotlin

--- a/access_card/build.gradle
+++ b/access_card/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation libs.rx_helpers

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -3,8 +3,8 @@ dependencies {
     kapt libs.dagger_compiler
     implementation libs.dagger
     implementation project(":localization")
-    implementation project(":membership")
     implementation project(":location")
+    implementation project(":membership")
 
     api libs.kotlin
     api libs.ga

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,4 @@
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-
 String buildMetadata
 
 if (project.hasProperty('build_number')) {

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/build.gradle
+++ b/build.gradle
@@ -106,10 +106,13 @@ subprojects {
         apply plugin: 'com.android.library'
     }
     apply plugin: 'kotlin-android'
-    if (name != 'analytics' && name != 'image') {
-        // Most modules make use of the synthetic accessors; ':db' uses the experimental 'Parcelize' annotation, so it does some configuration beyond that.
-        apply plugin: 'kotlin-android-extensions'
-    }
+    // Most modules make use of the synthetic 'findViewById' accessors, part of
+    // the 'kotlin-android-extensions' plugin. The ':db' module goes beyond, as
+    // it also takes advantage of the experimental 'Parcelize' annotation.
+    //
+    // Any module that needs experimental features should enable such in the
+    // associated build.gradle, not here.
+    apply plugin: 'kotlin-android-extensions'
     apply plugin: 'kotlin-kapt'
 
     android {

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,10 @@ subprojects {
         apply plugin: 'com.android.library'
     }
     apply plugin: 'kotlin-android'
+    if (name != 'analytics' && name != 'image') {
+        // Most modules make use of the synthetic accessors; ':db' uses the experimental 'Parcelize' annotation, so it does some configuration beyond that.
+        apply plugin: 'kotlin-android-extensions'
+    }
     apply plugin: 'kotlin-kapt'
 
     android {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         exo_player_version = '2.9.0'
 
         libs = [
-                kotlin                  : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
+                kotlin                  : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version",
                 rx_helpers              : "com.github.fuzz-productions:rx-helpers:${latest_helper}",
                 dagger                  : "com.google.dagger:dagger:${dagger_version}",
                 dagger_android          : "com.google.dagger:dagger-android-support:${dagger_version}",

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,8 @@ subprojects {
     // Any module that needs experimental features should enable such in the
     // associated build.gradle, not here.
     apply plugin: 'kotlin-android-extensions'
+    // FIXME: Minimize usage of the 'kapt' directive where possible
+    // (it can significantly slow down the build process)
     apply plugin: 'kotlin-kapt'
 
     android {

--- a/content_listing/build.gradle
+++ b/content_listing/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -1,6 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.android.library'
 
 android {
     buildTypes {

--- a/details/build.gradle
+++ b/details/build.gradle
@@ -11,13 +11,13 @@ dependencies {
     implementation libs.arch_navigation
     implementation libs.arch_navigation_ui
     implementation libs.constraint_layout
-    implementation project(':ui')
-    implementation project(':db')
-    implementation project(':viewmodel')
-    implementation project(':base')
     implementation project(':adapter')
+    implementation project(':base')
+    implementation project(':db')
+    implementation project(':image')
     implementation project(':localization')
     implementation project(':media')
     implementation project(':media_ui')
-    implementation project(':image')
+    implementation project(':ui')
+    implementation project(':viewmodel')
 }

--- a/details/build.gradle
+++ b/details/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/image/build.gradle
+++ b/image/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     api libs.glide

--- a/info/build.gradle
+++ b/info/build.gradle
@@ -10,18 +10,18 @@ dependencies {
 
     api libs.design_support
     implementation libs.glide
-    implementation project(':base')
-    implementation project(':ui')
-    implementation project(':viewmodel')
-    implementation project(':navigation')
-    implementation project(':search')
-    implementation project(':media_ui')
-    implementation project(':db')
-    implementation project(':membership')
     implementation project(':access_card')
-    implementation project(':location')
+    implementation project(':base')
+    implementation project(':db')
     implementation project(':localization')
     implementation project(':localization_ui')
+    implementation project(':location')
+    implementation project(':media_ui')
+    implementation project(':membership')
+    implementation project(':navigation')
+    implementation project(':search')
+    implementation project(':ui')
+    implementation project(':viewmodel')
     implementation libs.constraint_layout
     implementation libs.rx_helpers
     implementation libs.rx_kotlin

--- a/info/build.gradle
+++ b/info/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 
 dependencies {

--- a/localization/build.gradle
+++ b/localization/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':base')

--- a/localization_ui/build.gradle
+++ b/localization_ui/build.gradle
@@ -1,9 +1,9 @@
 
 dependencies {
     implementation project(':base')
+    implementation project(':localization')
     implementation project(':ui')
     implementation project(':viewmodel')
-    implementation project(':localization')
 
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler

--- a/localization_ui/build.gradle
+++ b/localization_ui/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':base')

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':base')

--- a/location_ui/build.gradle
+++ b/location_ui/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':base')

--- a/location_ui/build.gradle
+++ b/location_ui/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     implementation libs.location
     implementation libs.constraint_layout
     implementation project(':analytics')
+    implementation project(':location')
     implementation project(':ui')
     implementation project(':viewmodel')
-    implementation project(':location')
 
 }

--- a/map/build.gradle
+++ b/map/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs'
 
 android {

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
 

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation libs.media_compat
     implementation libs.glide
     implementation libs.exo_player_media_session
+    implementation project(':analytics')
     implementation project(':base')
     implementation project(':db')
-    implementation project(':analytics')
 }

--- a/media_ui/build.gradle
+++ b/media_ui/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     kapt libs.dagger_compiler

--- a/media_ui/build.gradle
+++ b/media_ui/build.gradle
@@ -9,13 +9,13 @@ dependencies {
     implementation libs.constraint_layout
     implementation project(':viewmodel')
     implementation libs.rx_helpers
-    implementation project(':base')
-    implementation project(':ui')
-    implementation project(':media')
-    implementation project(':db')
-    implementation project(':navigation')
-    implementation project(':viewmodel')
     implementation project(':adapter')
+    implementation project(':base')
+    implementation project(':db')
     implementation project(':image')
+    implementation project(':media')
+    implementation project(':navigation')
     implementation project(':tour_manager')
+    implementation project(':ui')
+    implementation project(':viewmodel')
 }

--- a/membership/build.gradle
+++ b/membership/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 android {
     buildTypes {

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     api libs.design_support

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -1,7 +1,8 @@
 
 dependencies {
     api libs.design_support
-    implementation libs.glide
+
     implementation project(':base')
     implementation libs.constraint_layout
+    implementation libs.glide
 }

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
 

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -4,20 +4,20 @@ dependencies {
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
     implementation libs.threeten
-    implementation project(':base')
-    implementation project(':db')
-    implementation project(':analytics')
-    implementation project(':ui')
-
     implementation libs.glide
     implementation libs.constraint_layout
     implementation libs.rx_helpers
     implementation libs.rx_kotlin
-    implementation project(':viewmodel')
-    implementation project(':image')
+
     implementation project(':adapter')
-    implementation project(':navigation')
+    implementation project(':analytics')
+    implementation project(':base')
+    implementation project(':db')
     implementation project(':details')
-    implementation project(':media_ui')
+    implementation project(':image')
     implementation project(':localization')
+    implementation project(':media_ui')
+    implementation project(':navigation')
+    implementation project(':ui')
+    implementation project(':viewmodel')
 }

--- a/splash/build.gradle
+++ b/splash/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation libs.rx_helpers

--- a/splash/build.gradle
+++ b/splash/build.gradle
@@ -3,13 +3,13 @@ dependencies {
     implementation libs.rx_helpers
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
-    implementation project(':ui')
-    implementation project(':base')
-    implementation project(':viewmodel')
-    implementation project(':db')
-    implementation project(':navigation')
-    implementation project(':localization_ui')
     implementation project(':analytics')
+    implementation project(':base')
+    implementation project(':db')
+    implementation project(':localization_ui')
+    implementation project(':navigation')
+    implementation project(':ui')
+    implementation project(':viewmodel')
     implementation libs.constraint_layout
     api libs.arch_runtime
     api libs.arch_extensions

--- a/tour_manager/build.gradle
+++ b/tour_manager/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs'
 
 dependencies {

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,17 +1,19 @@
 
 
 dependencies {
-    implementation libs.rx_helpers
 
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
+
+    implementation project(":base")
+    implementation libs.rx_helpers
+    implementation libs.constraint_layout
+
+    api project(":analytics")
+    api project(":localization")
+    api project(":navigation")
     api libs.dagger
     api libs.dagger_android
-    implementation libs.constraint_layout
-    implementation project(":base")
-    api project(":localization")
-    api project(":analytics")
-    api project(":navigation")
     api libs.arch_navigation
     api libs.arch_navigation_ui
     api "com.android.support:appcompat-v7:${support_version}"

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 
 dependencies {

--- a/viewmodel/build.gradle
+++ b/viewmodel/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation project(':ui')

--- a/welcome/build.gradle
+++ b/welcome/build.gradle
@@ -1,26 +1,26 @@
 
 dependencies {
-    implementation libs.constraint_layout
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
+
     api libs.design_support
-    implementation libs.threeten
-    implementation project(':base')
-    implementation libs.constraint_layout
-    implementation project(':ui')
-    implementation project(':db')
-    implementation project(':viewmodel')
-    implementation project(':base')
-    implementation project(':media_ui')
-    implementation project(':adapter')
-    implementation project(':content_listing')
-    implementation project(':navigation')
-    implementation project(':media')
-    implementation project(':image')
-    implementation project(':search')
-    implementation project(':details')
-    implementation project(':membership')
+
     implementation project(':access_card')
+    implementation project(':adapter')
+    implementation project(':base')
+    implementation project(':content_listing')
+    implementation project(':db')
+    implementation project(':details')
+    implementation project(':image')
+    implementation project(':media')
+    implementation project(':media_ui')
+    implementation project(':membership')
+    implementation project(':navigation')
+    implementation project(':search')
+    implementation project(':ui')
+    implementation project(':viewmodel')
+    implementation libs.constraint_layout
+    implementation libs.threeten
     implementation libs.exo_player_core
     implementation libs.exo_player_ui
 }

--- a/welcome/build.gradle
+++ b/welcome/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation libs.constraint_layout


### PR DESCRIPTION
This is the first in what will hopefully be a series of regular maintenance changesets. This deals primarily with standardizing the 27 `build.gradle` files currently included in the repository.

While the functionality of output APKs should not be different, with any luck these changes will shed some light onto our ongoing build instability. Specific fixes for that issue are being developed at #285.

Included in this PR:
1. Update Kotlin Libs from JDK 7 variant to JDK 8 variant
2. Remove duplicate `apply plugin: X` lines from 26 `build.gradle` files
    - Here's a breakdown of the duplicates:
        - `com.android.library` (x1)
        - `kotlin-android` (x2)
        - `kotlin-android-extensions` (x24)
        - `kotlin-kapt` (x25)
    - Of these, only `kotlin-android-extensions` was not applied by the root `build.gradle`, so that had to be done as well
3. Use the same sorting logic for all of the `dependencies` blocks, with three primary goals
    1. Make it easier to see what each module is actually bringing in
    2. Reduce the chance of merge conflicts if two different contributors need to modify the same gradle configs
    3. Call out frequently-used modules for inclusion in [MODULES.md](MODULES.md)