### PR TITLE
Stop persisting search icon's 'wash' state across sections (AIC-592)

### DIFF
--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -45,7 +45,11 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
         // update our content when offset changes.
         addOnOffsetChangedListener(OnOffsetChangedListener { aBarLayout, verticalOffset ->
             val progress: Double = 1 - Math.abs(verticalOffset) / aBarLayout.totalScrollRange.toDouble()
-            searchIcon.background.alpha = (progress * 255).toInt()
+
+            // The search icon's background is also known as the 'wash'. Its state
+            // must be distinct from that of its counterparts in other
+            // ArticMainAppBarLayouts - hence the `Drawable::mutate` call.
+            searchIcon.background.mutate().alpha = (progress * 255).toInt()
             icon.drawable.alpha = (progress * 255).toInt()
             expandedImage.drawable.alpha = (progress * 255).toInt()
             subTitle.alpha = progress.toFloat()

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -45,13 +45,14 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
         // update our content when offset changes.
         addOnOffsetChangedListener(OnOffsetChangedListener { aBarLayout, verticalOffset ->
             val progress: Double = 1 - Math.abs(verticalOffset) / aBarLayout.totalScrollRange.toDouble()
+            val progressOutOf255: Int = (progress * 255).toInt()
 
             // The search icon's background is also known as the 'wash'. Its state
             // must be distinct from that of its counterparts in other
             // ArticMainAppBarLayouts - hence the `Drawable::mutate` call.
-            searchIcon.background.mutate().alpha = (progress * 255).toInt()
-            icon.drawable.alpha = (progress * 255).toInt()
-            expandedImage.drawable.alpha = (progress * 255).toInt()
+            searchIcon.background.mutate().alpha = progressOutOf255
+            icon.drawable.alpha = progressOutOf255
+            expandedImage.drawable.alpha = progressOutOf255
             subTitle.alpha = progress.toFloat()
         })
 


### PR DESCRIPTION
For a bit of background, we use the same immutable `Drawable` object whenever we load the resource id. This is usually just a nice memory-saving benefit of using default Resource-loading logic.

In the case of the search icons' background (defined in style `@style/Search.PrimaryScreen`, known formally as the 'wash'), this behavior is at the cause of some minor inconsistency. The wash's transparency should reflect its host fragment's scroll state.