### PR TITLE
Account for weightless tours (AIC-597)

### DIFF
--- a/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
+++ b/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
@@ -1,5 +1,6 @@
 package edu.artic.db
 
+import android.arch.persistence.db.SupportSQLiteOpenHelper
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
@@ -36,6 +37,10 @@ class AppDataManagerTest {
         appDataPrefManager = mock()
 
         database = mock()
+        // The 'OpenHelper' is marked as non-null, and we access it in AppDataManager to work around a bug in Room 2.0-
+        val openHelper: SupportSQLiteOpenHelper = mock()
+        doReturn(openHelper).`when`(database).openHelper
+
         appDataProvider = mock()
         appDataManager = AppDataManager(serviceProvider = appDataProvider,
                 appDataPreferencesManager = appDataPrefManager,

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         paging_version = '1.0.0-beta1'
         rx_binding_version = '2.1.1'
         kotshi_version = '1.0.4'
-        moshi_version = '1.6.0'
+        moshi_version = '1.7.0'
         room_version = '1.1.1'
         glide_version = '4.4.0'
         firebase_version = '16.0.4'

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -172,7 +172,7 @@ class AppDataManager @Inject constructor(
                                 objectDao.addObjects(objects.values.toList())
                             }
 
-                            val tours = result.tours
+                            val tours = result.tours?.filter { it.weight != null }
                             if (tours?.isNotEmpty() == true) {
                                 tourDao.clear()
                                 tours.forEach { tour ->

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -251,6 +251,14 @@ class AppDataManager @Inject constructor(
      */
     @WorkerThread
     private fun enforceSanityCheck() {
+        // Make sure we're not bitten by https://issuetracker.google.com/issues/111504749
+        // TODO: Remove this '::close' when we start using Room 2.1.0-a1 or higher
+        if (!appDatabase.isOpen) {
+            // This _should_ be a no-op, but in Room 2.0.0 and earlier it may release a stale database reference.
+            appDatabase.openHelper.close()
+            // If it did release a reference, the next line will throw with a helpful (though long) error message
+        }
+
         if (generalInfoDao.getRowCount() != 1 || dataObjectDao.getRowCount() != 1) {
             // Absolutely no reason to keep previous data. Destroy it.
             appDataPreferencesManager.lastModified = ""

--- a/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
@@ -22,7 +22,7 @@ import edu.artic.db.models.*
             ArticMapFloor::class,
             ArticSearchSuggestionsObject::class
         ],
-        version = 8,
+        version = 9,
         exportSchema = false
 )
 @TypeConverters(AppConverters::class)

--- a/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
+++ b/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
@@ -73,10 +73,10 @@ class FloorAdapter {
 
     @FromJson
     @Floor
-    fun fromText(text: String?): Int {
+    fun fromText(@Nullable text: String?): Int {
         return if (text != null) {
-            try {
-                return text.toInt()
+            return try {
+                text.toInt()
             } catch (e: NumberFormatException) {
                 /** "LL" stands for 'Lower level' **/
                 if (text == "LL") {

--- a/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
+++ b/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
@@ -17,10 +17,6 @@ inline fun getMoshi(configureBlock: (Moshi.Builder.() -> Unit) = {}): Moshi =
                 .apply { configureBlock(this) }
                 .build()
 
-/**
- * Used to explicitly reference without needing to inject it into [SCError] for convenience.
- */
-internal val apiErrorMoshi: Moshi = getMoshi()
 
 fun Moshi.Builder.registerAdapters() = apply {
     add(KotlinJsonAdapterFactory())

--- a/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
+++ b/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
@@ -1,5 +1,6 @@
 package edu.artic.db
 
+import android.annotation.SuppressLint
 import android.support.annotation.Nullable
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonQualifier
@@ -64,12 +65,42 @@ class ZonedDateTimeAdapter {
 }
 
 /**
- * Parses floor as an integer. We default to [INVALID_FLOOR] as 0 and negative numbers are valid floors.
+ * Parses floor as an integer. We default to [INVALID_FLOOR] as 0 and
+ * negative numbers are valid floors.
+ *
+ *
+ * In the past, bugs related to this class have arisen (from Retrofit2) as
+ *
+ * `Unable to create converter for class edu.artic.db.models.ArticAppData for method AppDataApi.getBlob`
+ *
+ * or (from Moshi)
+ *
+ * `Non-null value 'floor' was null at $.some.path.`
  */
 class FloorAdapter {
 
     @ToJson
     fun toText(@Floor floor: Int): String = floor.toString()
+
+    /**
+     * Due to a bug in Moshi 1.7.0, we require two overloads of this int converter.
+     */
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    @ToJson
+    fun toTextBoxed(@Floor floor: java.lang.Integer): String = floor.toString()
+
+    /**
+     * Due to a bug in Moshi 1.7.0, we require two overloads of this int converter.
+     *
+     * Due to a bug in Kotlin 1.2.71, we must use the `java.lang.Integer` constructor.
+     */
+    @SuppressLint("UseValueOf")
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    @FromJson
+    @Floor
+    fun fromTextBoxed(@Nullable text: String?): java.lang.Integer {
+        return java.lang.Integer(fromText(text))
+    }
 
     @FromJson
     @Floor

--- a/db/src/main/kotlin/edu/artic/db/models/ArticTour.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticTour.kt
@@ -48,7 +48,14 @@ data class ArticTour(
         @Json(name = "tour_duration") val tourDuration: String?,
         @Json(name = "tour_audio") val tourAudio: String?,
         @Json(name = "category") @Embedded(prefix = "tour_cat") val category: TourCategory?,
-        @Json(name = "weight") val weight: Int,
+        /**
+         * This field lets tours be ordered differently at runtime. If it's
+         * missing, the tour is not valid and must not be used.
+         *
+         * Such filtering may be done by the database transaction in
+         * [AppDataManager.getBlob].
+         */
+        @Json(name = "weight") val weight: Int?,
         @Json(name = "tour_stops") val tourStops: MutableList<TourStop>
 
 ) : Parcelable, Playable, AccessibilityAware {


### PR DESCRIPTION
Some ArticTour objects may not come with a valid `weight` property. Until we derive a more generic solution for unexpected data formation, this will prevent issues at application startup caused by not detecting this property.