### PR TITLE
Decrease map's initial zoom level just a little (AIC-604)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
@@ -13,7 +13,7 @@ data class MapChangeEvent(val focus: MapFocus, val floor: Int, val displayMode: 
 typealias ZoomLevel = Float
 
 const val ZOOM_LANDMARK: ZoomLevel = 17.5f
-const val ZOOM_INITIAL: ZoomLevel = 17.6f;
+const val ZOOM_INITIAL: ZoomLevel = 17.4f
 const val ZOOM_DEPARTMENTS: ZoomLevel = 18.0f
 const val ZOOM_DEPARTMENT_AND_SPACES: ZoomLevel = 19.0f
 const val ZOOM_INDIVIDUAL: ZoomLevel = 20.3f


### PR DESCRIPTION
While @caguilar187 was working on the Tour code, he increased the default zoom a little. That change was enough for departments to show up upon first load. Following some discussion thereof, we decided that this would make it harder to take in the building names and the general shape of the museum. This PR encapsulates that decision.