### PR TITLE
Map: Focuses the correct tour stop marker (AIC-584)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/MapItemRenderer.kt
@@ -291,10 +291,18 @@ abstract class MapItemRenderer<T : AccessibilityAware>(
                     map = map,
                     floor = floor,
                     id = id,
+                    isSelected = shouldFocusOnCreation(mapChangeEvent.displayMode),
                     // bitmap queue not used, means bitmap is considered loaded
                     loadedBitmap = !useBitmapQueue,
                     requestDisposable = requestDisposable)
         }
+    }
+
+    /**
+     * This method is called by [displayMarker], later it is used to focus the marker.
+     */
+    protected  open fun shouldFocusOnCreation(displayMode: MapDisplayMode): Boolean {
+        return false
     }
 
     /**
@@ -330,6 +338,7 @@ abstract class MapItemRenderer<T : AccessibilityAware>(
                         map = map,
                         floor = floor,
                         id = id,
+                        isSelected = shouldFocusOnCreation(displayMode),
                         loadedBitmap = true,
                         requestDisposable = null)
                 synchronized(tempMarkers) {
@@ -375,6 +384,7 @@ abstract class MapItemRenderer<T : AccessibilityAware>(
             floor: Int,
             id: String,
             loadedBitmap: Boolean,
+            isSelected: Boolean,
             requestDisposable: Disposable?
     ): MarkerHolder<T> {
         val targetAlpha = getMarkerAlpha(floor,
@@ -395,7 +405,15 @@ abstract class MapItemRenderer<T : AccessibilityAware>(
                     tag = MarkerMetaData(item, loadedBitmap, requestDisposable)
                 })
 
+
         markerHolder.marker.fadeIn(targetAlpha)
+
+        /**
+         * Focus the selected object.
+         */
+        if (isSelected) {
+            markerHolder.marker.showInfoWindow()
+        }
 
         return markerHolder
     }

--- a/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/ObjectsMapItemRenderer.kt
@@ -145,6 +145,12 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
             scaledDot
         }
 
+        val isSelectedTourStop = if (mapChangeEvent.displayMode is MapDisplayMode.Tour) {
+            mapChangeEvent.displayMode.selectedTourStop?.objectId == id
+        } else {
+            false
+        }
+
         // fast bitmap returns immediately.
         return constructAndAddMarkerHolder(
                 item = item,
@@ -155,6 +161,7 @@ class ObjectsMapItemRenderer(private val objectsDao: ArticObjectDao)
                 id = id,
                 // bitmap queue not used, means bitmap is considered loaded
                 loadedBitmap = !useBitmapQueue,
+                isSelected = isSelectedTourStop,
                 requestDisposable = requestDisposable)
     }
 

--- a/map/src/main/kotlin/edu/artic/map/rendering/TourIntroMapItemRenderer.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/TourIntroMapItemRenderer.kt
@@ -13,7 +13,6 @@ import edu.artic.map.ArticObjectMarkerGenerator
 import edu.artic.map.MapDisplayMode
 import edu.artic.map.MapFocus
 import edu.artic.map.helpers.toLatLng
-import edu.artic.ui.util.asCDNUri
 import io.reactivex.Flowable
 import io.reactivex.Observable
 
@@ -55,6 +54,14 @@ class TourIntroMapItemRenderer : MapItemRenderer<ArticTour>(useBitmapQueue = tru
             if (item.floorAsInt == floor) ALPHA_VISIBLE else ALPHA_DIMMED
         } else {
             ALPHA_VISIBLE
+        }
+    }
+
+    override fun shouldFocusOnCreation(displayMode: MapDisplayMode): Boolean {
+        return if (displayMode is MapDisplayMode.Tour) {
+            displayMode.selectedTourStop?.objectId == INTRO_TOUR_STOP_OBJECT_ID
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
When the map is loaded in tour mode with specific tour stop, that tour stop needs to be focused. This PR adds the feature to tag the marker (the one to be focused) as the selected marker and then focus it later when created.
Fixes both AIC-584 and AIC-595.

