### PR TITLE
Update time-parsing library dependencies for November 2018

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     // Our tests use the standard Java variant of the 310 backport..
-    testImplementation('org.threeten:threetenbp:1.3.3') {
+    testImplementation('org.threeten:threetenbp:1.3.7') {
         // ...so we need to explicitly exclude the Android variant here
         exclude group: 'com.jakewharton.threetenabp', module: 'threetenabp'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ buildscript {
                 room_compiler           : "android.arch.persistence.room:compiler:${room_version}",
                 room_rx                 : "android.arch.persistence.room:rxjava2:${room_version}",
                 timber                  : 'com.jakewharton.timber:timber:4.5.1',
-                threeten                : 'com.jakewharton.threetenabp:threetenabp:1.0.5',
+                threeten                : 'com.jakewharton.threetenabp:threetenabp:1.1.1',
                 v4_support              : "com.android.support:support-v4:${support_version}",
                 design_support          : "com.android.support:design:${support_version}",
                 constraint_layout       : "com.android.support.constraint:constraint-layout:2.0.0-alpha2",


### PR DESCRIPTION
This was sparked by an update to the Android backport of 310 from v1.0.5 to 1.1.1. This implied an update of the main 310 library to v1.3.7 from 1.3.3, and _that_ brought the timezone data itself from the 2016j release to the 2018e one.

For release info, check out
* https://github.com/JakeWharton/ThreeTenABP/blob/master/CHANGELOG.md#version-111-2018-10-12
* https://www.threeten.org/threetenbp/changes-report.html
* various threads in http://mm.icann.org/pipermail/tz-announce/