### PR TITLE
Adjust map marker text (AIC-591)

### DIFF
--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -338,13 +338,13 @@
     </style>
 
     <style name="MarkerDepartmentText">
-        <item name="android:fontFamily">@font/ideal_sans_medium</item>
+        <item name="android:fontFamily">@font/ideal_sans_book</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">@dimen/textSixteen</item>
     </style>
 
     <style name="MarkerGalleryText">
-        <item name="android:fontFamily">@font/ideal_sans_medium</item>
+        <item name="android:fontFamily">@font/ideal_sans_book</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">15sp</item>
     </style>

--- a/map/src/main/res/layout/fragment_map.xml
+++ b/map/src/main/res/layout/fragment_map.xml
@@ -110,15 +110,16 @@
             android:layout_marginTop="@dimen/marginDouble"
             tools:text="Find Your Way"
             />
-        
+
         <TextView
             android:id="@+id/mapFirstRunHeaderSubtitle"
             style="@style/PageSubHeaderRegularWhite"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/marginOneHalf"
+            android:layout_marginTop="@dimen/marginTen"
             android:layout_marginStart="@dimen/marginActivitySubtitle"
             android:layout_marginEnd="@dimen/marginActivitySubtitle"
+            android:layout_marginBottom="@dimen/marginSixtyFour"
             tools:text="Use the map to find food, facilities, and audio-enhanced artworks."
             />
     </LinearLayout>

--- a/map/src/main/res/layout/view_marker_department.xml
+++ b/map/src/main/res/layout/view_marker_department.xml
@@ -51,11 +51,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:textAlignment="center"
             android:gravity="center"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
             app:layout_constraintStart_toEndOf="@id/departmentImage"
-            tools:text="Testing"/>
+            tools:text="Some long text (for testing) here."/>
 
     </LinearLayout>
 

--- a/map/src/main/res/layout/view_marker_text.xml
+++ b/map/src/main/res/layout/view_marker_text.xml
@@ -14,6 +14,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:textAlignment="center"
         tools:text="1"
         />
 


### PR DESCRIPTION
This PR
* decreases the font weight of textual markers
* center-aligns that text
* adds more vertical padding to the banner at the top of the map screen