### PR TITLE
Increase Exhibitions' dateline text to be 16sp (AIC-588)

### DIFF
--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -133,7 +133,7 @@
     </style>
 
     <style name="CardBodySmallItalic">
-        <item name="android:textSize">@dimen/textSmallest</item>
+        <item name="android:textSize">@dimen/textSixteen</item>
         <item name="android:textColor">@color/greyText</item>
         <item name="android:fontFamily">@font/amiri_italic</item>
     </style>


### PR DESCRIPTION
Previously it was `textSmallest`, or 12sp on most devices.