### PR TITLE
Add perforation line to ticket icon (AIC-589)

### DIFF
--- a/base/src/main/res/drawable/ic_ticket.xml
+++ b/base/src/main/res/drawable/ic_ticket.xml
@@ -9,7 +9,7 @@
     <group
         android:pivotX="12.5"
         android:pivotY="12.5"
-        android:rotation="90"
+        android:rotation="270"
         >
         <path
             android:fillType="evenOdd"

--- a/base/src/main/res/drawable/ic_ticket.xml
+++ b/base/src/main/res/drawable/ic_ticket.xml
@@ -14,6 +14,16 @@
         <path
             android:fillType="evenOdd"
             android:pathData="
+            M 10.820312 19.375
+            L 19.398438 10.796875"
+            android:strokeLineCap="square"
+            android:strokeWidth="1.145"
+            android:strokeColor="#FFFFFF"
+            />
+
+        <path
+            android:fillType="evenOdd"
+            android:pathData="
             M 21.570 17.132
             C 20.929 16.660 20.101 16.429 19.210 16.597
             C 17.996 16.824 17.023 17.824 16.824 19.046

--- a/base/src/main/res/drawable/ic_ticket.xml
+++ b/base/src/main/res/drawable/ic_ticket.xml
@@ -12,6 +12,7 @@
         android:rotation="270"
         >
         <path
+            android:name="stub_perforation"
             android:fillType="evenOdd"
             android:pathData="
             M 10.820312 19.375
@@ -22,6 +23,7 @@
             />
 
         <path
+            android:name="ticket_outline"
             android:fillType="evenOdd"
             android:pathData="
             M 21.570 17.132


### PR DESCRIPTION
In keeping with the skeuomorphic design of our ticket icon, I've restored the line which runs perpendicular across the icon proper. This was present in the original Swift assets but I managed to miss it in #325.