### PR TITLE
Map Crash fix : (AIC-616)

### DIFF
--- a/map/src/main/kotlin/edu/artic/map/MapFragment.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapFragment.kt
@@ -207,16 +207,21 @@ class MapFragment : BaseViewModelFragment<MapViewModel>() {
              * Purpose of setting this infoWindowAdapter is for displaying an empty info window.
              */
             setInfoWindowAdapter(object : GoogleMap.InfoWindowAdapter {
-                override fun getInfoContents(p0: Marker?): View {
-                    return View(requireContext())
+
+                override fun getInfoContents(p0: Marker?): View? {
+                    return context?.let { ctx ->
+                        View(ctx)
+                    }
                 }
 
-                override fun getInfoWindow(p0: Marker?): View? {
+                override fun getInfoWindow(marker: Marker?): View? {
                     /**
                      * Returning empty textView or view didn't work so added TextView with spaces.
                      */
-                    return TextView(requireContext()).apply {
-                        text = " "
+                    return context?.let {ctx->
+                        TextView(ctx).apply {
+                            text = " "
+                        }
                     }
                 }
             })


### PR DESCRIPTION
`requireContext()` was returning exception. Now uses nullable context and only shows `infoWindow` if the context is not null.