### PR TITLE
[Navigation] Simplify the handling of link from Welcome screen to Member Card

### DIFF
--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -2,11 +2,9 @@ package edu.artic.info
 
 import android.content.Intent
 import android.os.Bundle
-import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.disableShiftMode
 import edu.artic.location.LocationService
 import edu.artic.location.LocationServiceImpl
-import edu.artic.navigation.NavigationConstants
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.linkHome
 import edu.artic.ui.BaseActivity
@@ -45,40 +43,22 @@ class InfoActivity : BaseActivity() {
         }
     }
 
+    /**
+     * DeepLinking does not work by default when activity is reordered to front.
+     * So we need to handle it manually.
+     */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        /**
-         * DeepLinking does not work by default when activity is reordered to front.
-         * So we need to handle it manually.
-         */
-        when (intent.data?.toString()?.replace("artic://", "")) {
-            NavigationConstants.INFO_MEMBER_CARD -> {
-
-                val navController = supportFragmentManager.findNavController()
-
-                val currentDestination = navController
-                        ?.currentDestination
-                        ?.label
-                        ?.toString()
-
-                /**
-                 * Go to access member card iff current destination's label is not [R.string.accessMemberCardLabel].
-                 * Label for [AccessMemberCardFragment] is [R.string.accessMemberCardLabel].
-                 */
-                if (currentDestination != resources.getString(R.string.accessMemberCardLabel)) {
-
-                    /**
-                     * If the active fragment is not the start_destination navController can't find
-                     * accessMemberCardLabel.
-                     */
-                    if (currentDestination != resources.getString(R.string.fragmentInformationLabel)) {
-                        navController?.navigateUp()
-                    }
-
-                    navController?.navigate(R.id.goToAccessMemberCard)
-                }
-            }
-
+        supportFragmentManager.findNavController()?.apply {
+            /**
+             * Normally, the root child fragment is [InformationFragment].
+             * But when the user navigates from access_info_card link from WelcomeFragment, the root
+             * fragment is [edu.artic.accesscard.AccessMemberCardFragment].
+             *
+             * We expect at most two fragment at a time in this graph.
+             */
+            popBackStack(R.id.informationFragment, false)
+            onHandleDeepLink(intent)
         }
     }
 

--- a/info/src/main/res/navigation/info_navigation_graph.xml
+++ b/info/src/main/res/navigation/info_navigation_graph.xml
@@ -22,9 +22,6 @@
             android:id="@+id/goToLocationSettings"
             app:destination="@id/locationSettingsFragment" />
         <action
-            android:id="@+id/goToAccessMemberCard"
-            app:destination="@id/accessMemberCardFragment" />
-        <action
             android:id="@+id/gotoLanguageSettings"
             app:destination="@id/languageSettingsFragment" />
     </fragment>
@@ -52,5 +49,9 @@
         android:name="edu.artic.localization.ui.LanguageSettingsFragment"
         android:label="fragment_language_settings"
         tools:layout="@layout/fragment_language_settings" />
+
+    <action
+        android:id="@+id/goToAccessMemberCard"
+        app:destination="@id/accessMemberCardFragment" />
 
 </navigation>


### PR DESCRIPTION
This PR salvages some of the improvements implied by #307.

It turns out that `InfoActivity` was duplicating a bunch of logic built into the Navigation library itself....