### PR TITLE
Properly checks if api calls error out  (AIC-594)

### DIFF
--- a/app/src/main/kotlin/edu/artic/ArticApp.kt
+++ b/app/src/main/kotlin/edu/artic/ArticApp.kt
@@ -27,7 +27,10 @@ class ArticApp : DaggerApplication(), LifecycleObserver {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
+        } else {
+            Timber.plant(CrashlyticsTree())
         }
+
         AndroidThreeTen.init(this)
         FirebaseApp.initializeApp(this, firebaseOptions())
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)

--- a/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
+++ b/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
@@ -20,20 +20,10 @@ class CrashlyticsTree : Timber.Tree() {
             return
         }
 
-        Crashlytics.setInt(CRASHLYTICS_KEY_PRIORITY, priority)
-        Crashlytics.setString(CRASHLYTICS_KEY_TAG, tag)
-        Crashlytics.setString(CRASHLYTICS_KEY_MESSAGE, message)
-
         Crashlytics.log(message)
 
         if (t != null) {
             Crashlytics.logException(t)
         }
-    }
-
-    companion object {
-        private const val CRASHLYTICS_KEY_PRIORITY = "priority"
-        private const val CRASHLYTICS_KEY_TAG = "tag"
-        private const val CRASHLYTICS_KEY_MESSAGE = "message"
     }
 }

--- a/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
+++ b/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
@@ -1,0 +1,39 @@
+package edu.artic
+
+import android.util.Log
+import com.crashlytics.android.Crashlytics
+import timber.log.Timber
+
+
+/**
+ * Sends the timber logs to Crashlytics.
+ * @author Sameer Dhakal (Fuzz)
+ */
+
+class CrashlyticsTree : Timber.Tree() {
+
+    private val reportableLogs: Set<Int> = setOf(Log.ERROR)
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+
+        if (reportableLogs.contains(priority)) {
+            return
+        }
+
+        Crashlytics.setInt(CRASHLYTICS_KEY_PRIORITY, priority)
+        Crashlytics.setString(CRASHLYTICS_KEY_TAG, tag)
+        Crashlytics.setString(CRASHLYTICS_KEY_MESSAGE, message)
+
+        Crashlytics.log(message)
+
+        if (t != null) {
+            Crashlytics.logException(t)
+        }
+    }
+
+    companion object {
+        private const val CRASHLYTICS_KEY_PRIORITY = "priority"
+        private const val CRASHLYTICS_KEY_TAG = "tag"
+        private const val CRASHLYTICS_KEY_MESSAGE = "message"
+    }
+}

--- a/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
+++ b/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
@@ -57,7 +57,8 @@ class AppDataManagerTest {
                 mapAnnotationDao = mock(),
                 tourDao = mock(),
                 searchSuggestionDao = mock(),
-                articMapFloorDao = mock()
+                articMapFloorDao = mock(),
+                appDataPrefManager = mock()
         )
     }
 

--- a/base/src/main/java/edu/artic/base/NetworkException.kt
+++ b/base/src/main/java/edu/artic/base/NetworkException.kt
@@ -9,12 +9,10 @@ class NetworkException(
 ) : PermissibleError(message, cause)
 
 /**
- * Exceptions that do not create the app in an unstable state.
- * E.g. Network exceptions are PermissibleError.
- * If this exception is encountered during data loading process, user is allowed to use
- * the app (i.e. app is not stuck at splash screen). All other exceptions are not permitted.
+ * This is a non-fatal exception. E.g. Failure to refresh data
  *
- * @see [edu.artic.splash.SplashActivity]
+ * If something non-fatal happens during data loading process, we throw this kind of error and
+ * and it is caught in [edu.artic.splash.SplashActivity].
  */
 open class PermissibleError(
         override var message: String,

--- a/base/src/main/java/edu/artic/base/NetworkException.kt
+++ b/base/src/main/java/edu/artic/base/NetworkException.kt
@@ -4,18 +4,18 @@ package edu.artic.base
  * @author Sameer Dhakal (Fuzz)
  */
 class NetworkException(
-        override var message: String? = null,
-        override var cause: Throwable
-) : PermissibleException(message, cause)
+        override var message: String,
+        override var cause: Throwable? = null
+) : PermissibleError(message, cause)
 
 /**
  * Exceptions that do not create the app in an unstable state.
- * E.g. Network exceptions are PermissibleException.
+ * E.g. Network exceptions are PermissibleError.
  * If this exception is encountered during data loading process, user is allowed to use
  * the app (i.e. app is not stuck at splash screen). All other exceptions are not permitted.
  *
  * @see [edu.artic.splash.SplashActivity]
  */
-open class PermissibleException(
-        override var message: String? = null,
-        override var cause: Throwable) : Exception(message, cause)
+open class PermissibleError(
+        override var message: String,
+        override var cause: Throwable? = null) : Exception(message, cause)

--- a/base/src/main/java/edu/artic/base/NetworkException.kt
+++ b/base/src/main/java/edu/artic/base/NetworkException.kt
@@ -4,6 +4,18 @@ package edu.artic.base
  * @author Sameer Dhakal (Fuzz)
  */
 class NetworkException(
-        override var message: String,
-        override var cause: Throwable? = null
-) : Exception(message, cause)
+        override var message: String? = null,
+        override var cause: Throwable
+) : PermissibleException(message, cause)
+
+/**
+ * Exceptions that do not create the app in an unstable state.
+ * E.g. Network exceptions are PermissibleException.
+ * If this exception is encountered during data loading process, user is allowed to use
+ * the app (i.e. app is not stuck at splash screen). All other exceptions are not permitted.
+ *
+ * @see [edu.artic.splash.SplashActivity]
+ */
+open class PermissibleException(
+        override var message: String? = null,
+        override var cause: Throwable) : Exception(message, cause)

--- a/db/src/main/kotlin/edu/artic/ResultExtensions.kt
+++ b/db/src/main/kotlin/edu/artic/ResultExtensions.kt
@@ -15,8 +15,8 @@ import org.json.JSONObject
  * Only works iff the response body can be converted to JSONObject.
  * Looks for error, message and detail keys in order.
  */
-fun Result<*>.getErrorMessage(): String? {
-    var errorMessage: String? = null
+fun Result<*>.getErrorMessage(): String {
+    lateinit var errorMessage: String
     try {
         this.response().errorBody()?.also { errorBody ->
             val errorJSON = JSONObject(errorBody.string())
@@ -24,9 +24,11 @@ fun Result<*>.getErrorMessage(): String? {
                     .orIfNullOrBlank(errorJSON.optString("message"))
                     .orIfNullOrBlank(errorJSON.optString("Message"))
                     .orIfNullOrBlank(errorJSON.optString("detail"))
-                    .orIfNullOrBlank("")
+                    ?: "Something went wrong"
+
         }
     } catch (exception: Exception) {
+        errorMessage = "Something went wrong"
         exception.printStackTrace()
     }
     return errorMessage

--- a/db/src/main/kotlin/edu/artic/ResultExtensions.kt
+++ b/db/src/main/kotlin/edu/artic/ResultExtensions.kt
@@ -22,6 +22,7 @@ fun Result<*>.getErrorMessage(): String? {
             val errorJSON = JSONObject(errorBody.string())
             errorMessage = errorJSON.optString("error")
                     .orIfNullOrBlank(errorJSON.optString("message"))
+                    .orIfNullOrBlank(errorJSON.optString("Message"))
                     .orIfNullOrBlank(errorJSON.optString("detail"))
                     .orIfNullOrBlank("")
         }

--- a/db/src/main/kotlin/edu/artic/ResultExtensions.kt
+++ b/db/src/main/kotlin/edu/artic/ResultExtensions.kt
@@ -1,0 +1,43 @@
+package edu.artic
+
+import com.jakewharton.retrofit2.adapter.rxjava2.Result
+import edu.artic.base.utils.orIfNullOrBlank
+import org.json.JSONObject
+
+/**
+ * This file houses the extension functions for [com.jakewharton.retrofit2.adapter.rxjava2.Result]
+ * @author Sameer Dhakal (Fuzz)
+ */
+
+
+/**
+ * Extension method to parse the error message from the JSON.
+ * Only works iff the response body can be converted to JSONObject.
+ * Looks for error, message and detail keys in order.
+ */
+fun Result<*>.getErrorMessage(): String? {
+    var errorMessage: String? = null
+    try {
+        this.response().errorBody()?.also { errorBody ->
+            val errorJSON = JSONObject(errorBody.string())
+            errorMessage = errorJSON.optString("error")
+                    .orIfNullOrBlank(errorJSON.optString("message"))
+                    .orIfNullOrBlank(errorJSON.optString("detail"))
+                    .orIfNullOrBlank("")
+        }
+    } catch (exception: Exception) {
+        exception.printStackTrace()
+    }
+    return errorMessage
+}
+
+/**
+ * Throws the response exception.
+ */
+fun Result<*>.throwIfError(): Result<*> {
+    return if (this.isError) {
+        throw this.error()
+    } else {
+        this
+    }
+}

--- a/db/src/main/kotlin/edu/artic/db/ApiModule.kt
+++ b/db/src/main/kotlin/edu/artic/db/ApiModule.kt
@@ -52,7 +52,7 @@ abstract class ApiModule {
                 objectDao: ArticObjectDao,
                 articMapFloorDao: ArticMapFloorDao,
                 searchSuggestionDao: ArticSearchObjectDao,
-                appDaPrefManager: AppDataPreferencesManager
+                appDataPrefManager: AppDataPreferencesManager
         ): AppDataManager = AppDataManager(
                 serviceProvider,
                 appDataPreferencesManager,
@@ -70,7 +70,7 @@ abstract class ApiModule {
                 objectDao,
                 articMapFloorDao,
                 searchSuggestionDao,
-                appDaPrefManager
+                appDataPrefManager
         )
 
         @JvmStatic

--- a/db/src/main/kotlin/edu/artic/db/ApiModule.kt
+++ b/db/src/main/kotlin/edu/artic/db/ApiModule.kt
@@ -51,7 +51,8 @@ abstract class ApiModule {
                 exhibitionDao: ArticExhibitionDao,
                 objectDao: ArticObjectDao,
                 articMapFloorDao: ArticMapFloorDao,
-                searchSuggestionDao: ArticSearchObjectDao
+                searchSuggestionDao: ArticSearchObjectDao,
+                appDaPrefManager: AppDataPreferencesManager
         ): AppDataManager = AppDataManager(
                 serviceProvider,
                 appDataPreferencesManager,
@@ -68,7 +69,8 @@ abstract class ApiModule {
                 exhibitionDao,
                 objectDao,
                 articMapFloorDao,
-                searchSuggestionDao
+                searchSuggestionDao,
+                appDaPrefManager
         )
 
         @JvmStatic

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -39,7 +39,7 @@ class AppDataManager @Inject constructor(
         private val objectDao: ArticObjectDao,
         private val articMapFloorDao: ArticMapFloorDao,
         private val searchSuggestionDao: ArticSearchObjectDao,
-        private val appDaPrefManager: AppDataPreferencesManager
+        private val appDataPrefManager: AppDataPreferencesManager
 ) {
     companion object {
         const val HEADER_LAST_MODIFIED = "last-modified"
@@ -79,7 +79,7 @@ class AppDataManager @Inject constructor(
             //First load app data, once app data is successfully loaded
             getBlob().subscribe({ appDataState ->
                 if (appDataState is ProgressDataState.Done<*> || appDataState === ProgressDataState.Empty) {
-                    appDaPrefManager.downloadedNecessaryData = true
+                    appDataPrefManager.downloadedNecessaryData = true
                     loadSecondaryData()
                             .subscribe({ amountDownload ->
                                 observer.onNext(

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -38,7 +38,8 @@ class AppDataManager @Inject constructor(
         private val exhibitionDao: ArticExhibitionDao,
         private val objectDao: ArticObjectDao,
         private val articMapFloorDao: ArticMapFloorDao,
-        private val searchSuggestionDao: ArticSearchObjectDao
+        private val searchSuggestionDao: ArticSearchObjectDao,
+        private val appDaPrefManager: AppDataPreferencesManager
 ) {
     companion object {
         const val HEADER_LAST_MODIFIED = "last-modified"
@@ -78,6 +79,7 @@ class AppDataManager @Inject constructor(
             //First load app data, once app data is successfully loaded
             getBlob().subscribe({ appDataState ->
                 if (appDataState is ProgressDataState.Done<*> || appDataState === ProgressDataState.Empty) {
+                    appDaPrefManager.downloadedNecessaryData = true
                     loadSecondaryData()
                             .subscribe({ amountDownload ->
                                 observer.onNext(

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -3,6 +3,7 @@ package edu.artic.db
 import com.fuzz.retrofit.rx.requireValue
 import com.fuzz.rx.bindTo
 import com.jobinlawrance.downloadprogressinterceptor.ProgressEventBus
+import edu.artic.base.PermissibleException
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ArticDataObject
 import edu.artic.getErrorMessage
@@ -110,7 +111,7 @@ class RetrofitAppDataServiceProvider(
                                         )
                                     } else {
                                         val errorMessage: String? = it.getErrorMessage()
-                                        val error = Throwable(errorMessage, it.error())
+                                        val error = PermissibleException(errorMessage, it.error())
                                         Timber.e(error)
                                         observer.onError(error)
                                     }
@@ -155,7 +156,7 @@ class RetrofitAppDataServiceProvider(
                                         )
                                     } else {
                                         val errorMessage: String? = it.getErrorMessage()
-                                        val error = Throwable(errorMessage, it.error())
+                                        val error = PermissibleException(errorMessage, it.error())
                                         Timber.e(error)
                                         observer.onError(error)
                                     }

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -131,34 +131,35 @@ class RetrofitAppDataServiceProvider(
             dataObject.subscribeBy(
                     onError = { observer.onError(it) },
                     onNext = { dataObject ->
-                var url = dataObject.dataApiUrl + dataObject.eventsEndpoint
-                if (!url.contains("/search")) {
-                    url += "/search"
-                }
-                url += "?limit=500"
-
-                val postParams = ApiBodyGenerator.createEventQueryBody()
-
-                service.getEvents(EVENT_HEADER_ID, url, postParams)
-                        .subscribe({
-                            if (!it.isError) {
-                                observer.onNext(
-                                        ProgressDataState.Done(
-                                                it.requireValue(),
-                                                it.response().headers().toMultimap()
-                                        )
-                                )
-                            } else {
-                                observer.onError(it.error())
-                            }
-                        }, {
-                            observer.onError(it)
-                        }, {
-                            observer.onComplete()
+                        var url = dataObject.dataApiUrl + dataObject.eventsEndpoint
+                        if (!url.contains("/search")) {
+                            url += "/search"
                         }
+                        url += "?limit=500"
 
-                        )
-            })
+                        val postParams = ApiBodyGenerator.createEventQueryBody()
+
+                        service.getEvents(EVENT_HEADER_ID, url, postParams)
+                                .subscribe({
+                                    if (it.response().isSuccessful) {
+                                        observer.onNext(
+                                                ProgressDataState.Done(
+                                                        it.requireValue(),
+                                                        it.response().headers().toMultimap()
+                                                )
+                                        )
+                                    } else {
+                                        val errorMessage: String? = it.getErrorMessage()
+                                        observer.onError(Throwable(errorMessage, it.error()))
+                                    }
+                                }, {
+                                    observer.onError(it)
+                                }, {
+                                    observer.onComplete()
+                                }
+
+                                )
+                    })
         }
     }
 

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -3,7 +3,7 @@ package edu.artic.db
 import com.fuzz.retrofit.rx.requireValue
 import com.fuzz.rx.bindTo
 import com.jobinlawrance.downloadprogressinterceptor.ProgressEventBus
-import edu.artic.base.PermissibleException
+import edu.artic.base.PermissibleError
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ArticDataObject
 import edu.artic.getErrorMessage
@@ -110,8 +110,8 @@ class RetrofitAppDataServiceProvider(
                                                 )
                                         )
                                     } else {
-                                        val errorMessage: String? = it.getErrorMessage()
-                                        val error = PermissibleException(errorMessage, it.error())
+                                        val errorMessage: String = it.getErrorMessage()
+                                        val error = PermissibleError(errorMessage)
                                         Timber.e(error)
                                         observer.onError(error)
                                     }
@@ -155,8 +155,8 @@ class RetrofitAppDataServiceProvider(
                                                 )
                                         )
                                     } else {
-                                        val errorMessage: String? = it.getErrorMessage()
-                                        val error = PermissibleException(errorMessage, it.error())
+                                        val errorMessage: String = it.getErrorMessage()
+                                        val error = PermissibleError(errorMessage, it.error())
                                         Timber.e(error)
                                         observer.onError(error)
                                     }

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -2,10 +2,13 @@ package edu.artic.db
 
 import com.fuzz.retrofit.rx.requireValue
 import com.fuzz.rx.bindTo
+import com.jakewharton.retrofit2.adapter.rxjava2.Result
 import com.jobinlawrance.downloadprogressinterceptor.ProgressEventBus
 import edu.artic.base.PermissibleError
 import edu.artic.db.daos.ArticDataObjectDao
 import edu.artic.db.models.ArticDataObject
+import edu.artic.db.models.ArticEvent
+import edu.artic.db.models.ArticExhibition
 import edu.artic.getErrorMessage
 import edu.artic.throwIfError
 import io.reactivex.Observable
@@ -100,7 +103,7 @@ class RetrofitAppDataServiceProvider(
                         val postParams = ApiBodyGenerator.createExhibitionQueryBody()
 
                         service.getExhibitions(EXHIBITIONS_HEADER_ID, url, postParams)
-                                .map { it.throwIfError() }
+                                .map(Result<ArticResult<ArticExhibition>>::throwIfError)
                                 .subscribe({
                                     if (it.response().isSuccessful) {
                                         observer.onNext(
@@ -145,7 +148,7 @@ class RetrofitAppDataServiceProvider(
                         val postParams = ApiBodyGenerator.createEventQueryBody()
 
                         service.getEvents(EVENT_HEADER_ID, url, postParams)
-                                .map { it.throwIfError() }
+                                .map(Result<ArticResult<ArticEvent>>::throwIfError)
                                 .subscribe({
                                     if (it.response().isSuccessful) {
                                         observer.onNext(

--- a/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
+++ b/db/src/main/kotlin/edu/artic/db/RetrofitAppDataServiceProvider.kt
@@ -13,6 +13,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import retrofit2.Retrofit
+import timber.log.Timber
 
 /**
  * Reference implementation of [AppDataServiceProvider] for the Art Institute of Chicago.
@@ -109,7 +110,9 @@ class RetrofitAppDataServiceProvider(
                                         )
                                     } else {
                                         val errorMessage: String? = it.getErrorMessage()
-                                        observer.onError(Throwable(errorMessage, it.error()))
+                                        val error = Throwable(errorMessage, it.error())
+                                        Timber.e(error)
+                                        observer.onError(error)
                                     }
 
                                 }, {
@@ -152,7 +155,9 @@ class RetrofitAppDataServiceProvider(
                                         )
                                     } else {
                                         val errorMessage: String? = it.getErrorMessage()
-                                        observer.onError(Throwable(errorMessage, it.error()))
+                                        val error = Throwable(errorMessage, it.error())
+                                        Timber.e(error)
+                                        observer.onError(error)
                                     }
                                 }, {
                                     observer.onError(it)

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -17,6 +17,7 @@ import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import com.fuzz.rx.disposedBy
+import edu.artic.base.PermissibleException
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.makeStatusBarTransparent
 import edu.artic.localization.ui.LanguageSettingsFragment
@@ -90,7 +91,9 @@ class SplashActivity : BaseViewModelActivity<SplashViewModel>(), TextureView.Sur
                             .setTitle(resources.getString(R.string.errorDialogTitle))
                             .setMessage(errorMessage)
                             .setOnDismissListener { _ ->
-                                    viewModel.errorDialogDismissed()
+                                if (it is PermissibleException) {
+                                    viewModel.proceedToWelcomePageIfDataAvailable()
+                                }
                             }
                             .setPositiveButton(getString(android.R.string.ok)) { dialog, _->
                                 dialog.dismiss()

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -17,7 +17,6 @@ import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import com.fuzz.rx.disposedBy
-import edu.artic.base.NetworkException
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.makeStatusBarTransparent
 import edu.artic.localization.ui.LanguageSettingsFragment
@@ -91,9 +90,7 @@ class SplashActivity : BaseViewModelActivity<SplashViewModel>(), TextureView.Sur
                             .setTitle(resources.getString(R.string.errorDialogTitle))
                             .setMessage(errorMessage)
                             .setOnDismissListener { _ ->
-                                if (it is NetworkException) {
-                                    viewModel.onNetworkErrorDialogDismissed()
-                                }
+                                    viewModel.errorDialogDismissed()
                             }
                             .setPositiveButton(getString(android.R.string.ok)) { dialog, _->
                                 dialog.dismiss()

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -17,7 +17,7 @@ import android.view.*
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import com.fuzz.rx.disposedBy
-import edu.artic.base.PermissibleException
+import edu.artic.base.PermissibleError
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.makeStatusBarTransparent
 import edu.artic.localization.ui.LanguageSettingsFragment
@@ -91,7 +91,7 @@ class SplashActivity : BaseViewModelActivity<SplashViewModel>(), TextureView.Sur
                             .setTitle(resources.getString(R.string.errorDialogTitle))
                             .setMessage(errorMessage)
                             .setOnDismissListener { _ ->
-                                if (it is PermissibleException) {
+                                if (it is PermissibleError) {
                                     viewModel.proceedToWelcomePageIfDataAvailable()
                                 }
                             }

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -69,7 +69,7 @@ class SplashViewModel @Inject constructor(
     /**
      * Allow user to proceed forward if app has cache data.
      */
-    fun errorDialogDismissed() {
+    fun proceedToWelcomePageIfDataAvailable() {
         if (appDaPrefManager.downloadedNecessaryData) {
             Navigate.Forward(NavigationEndpoint.Welcome)
                     .asObservable()

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -66,8 +66,10 @@ class SplashViewModel @Inject constructor(
                 .disposedBy(disposeBag)
     }
 
-    
-    fun onNetworkErrorDialogDismissed() {
+    /**
+     * Allow user to proceed forward if app has cache data.
+     */
+    fun errorDialogDismissed() {
         if (appDaPrefManager.downloadedNecessaryData) {
             Navigate.Forward(NavigationEndpoint.Welcome)
                     .asObservable()

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -44,7 +44,6 @@ class SplashViewModel @Inject constructor(
                         is ProgressDataState.Done<*> -> {
                             percentage.onNext(1.0f)
                             startVideo()
-                            appDaPrefManager.downloadedNecessaryData = true
                         }
                         is ProgressDataState.Empty -> {
                             startVideo()


### PR DESCRIPTION
* App now allows a user to proceed to the home screen irrespective of any exception type (when cached data is available) that happens during data fetching process.
* Updates the `getEvents` & `getExhibitions` method to properly check for error response.