### PR TITLE
Reduce layout repetition in the welcome section

### DIFF
--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -75,13 +75,25 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                 .bindToMain(adapter.itemChanges())
                 .disposedBy(disposeBag)
 
+        viewModel.exhibitions
+                .map { it.isNotEmpty() }
+                .bindToMain(exhibitionSection.visibility())
+                .disposedBy(disposeBag)
+
+
         /* Build event summary list*/
         val eventsLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
         eventSection.list.layoutManager = eventsLayoutManager
         val eventsAdapter = WelcomeEventsAdapter()
         eventSection.list.adapter = eventsAdapter
+
         viewModel.events
                 .bindToMain(eventsAdapter.itemChanges())
+                .disposedBy(disposeBag)
+
+        viewModel.events
+                .map { it.isNotEmpty() }
+                .bindToMain(eventSection.visibility())
                 .disposedBy(disposeBag)
 
         viewModel.shouldPeekTourSummary
@@ -109,17 +121,6 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                     val title = resources.getString(R.string.welcomeUser, firstName)
                     requestTitleUpdate(title)
                 }
-                .disposedBy(disposeBag)
-
-        viewModel.events
-                .map { it.isNotEmpty() }
-                .bindToMain(eventSection.visibility())
-                .disposedBy(disposeBag)
-
-        viewModel.exhibitions
-                .map { it.isNotEmpty() }
-                .observeOn(AndroidSchedulers.mainThread())
-                .bindToMain(exhibitionSection.visibility())
                 .disposedBy(disposeBag)
 
     }

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -23,7 +23,6 @@ import edu.artic.tours.TourDetailsFragment
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.fragment_welcome.*
@@ -127,9 +126,9 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
 
     override fun setupBindings(viewModel: WelcomeViewModel) {
 
-        tourSection.label.text = resources.getString(R.string.tours)
-        exhibitionSection.label.text = resources.getString(R.string.onView)
-        eventSection.label.text = resources.getString(R.string.events)
+        tourSection.label.setText(R.string.tours)
+        exhibitionSection.label.setText(R.string.onView)
+        eventSection.label.setText(R.string.events)
 
         tourSection.seeAllLink.clicks()
                 .defaultThrottle()

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -10,6 +10,7 @@ import com.fuzz.rx.bindToMain
 import com.fuzz.rx.defaultThrottle
 import com.fuzz.rx.disposedBy
 import com.jakewharton.rxbinding2.view.clicks
+import com.jakewharton.rxbinding2.view.visibility
 import com.jakewharton.rxbinding2.widget.text
 import edu.artic.adapter.itemChanges
 import edu.artic.adapter.itemClicksWithPosition
@@ -22,9 +23,11 @@ import edu.artic.tours.TourDetailsFragment
 import edu.artic.viewmodel.BaseViewModelFragment
 import edu.artic.viewmodel.Navigate
 import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.fragment_welcome.*
+import kotlinx.android.synthetic.main.welcome_section.view.*
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
@@ -50,14 +53,14 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
 
         /* Build tour summary list*/
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
-        tourSummaryRecyclerView.layoutManager = layoutManager
+        tourSection.list.layoutManager = layoutManager
 
         val decoration = DividerItemDecoration(view.context, DividerItemDecoration.HORIZONTAL)
         decoration.setDrawable(ContextCompat.getDrawable(view.context, R.drawable.space_decorator)!!)
-        tourSummaryRecyclerView.addItemDecoration(decoration)
+        tourSection.list.addItemDecoration(decoration)
 
         val tourSummaryAdapter = WelcomeToursAdapter()
-        tourSummaryRecyclerView.adapter = tourSummaryAdapter
+        tourSection.list.adapter = tourSummaryAdapter
 
         viewModel.tours
                 .bindToMain(tourSummaryAdapter.itemChanges())
@@ -66,17 +69,17 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
         /* Build on view list*/
         val adapter = OnViewAdapter()
         val exhibitionLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
-        onViewRecyclerView.layoutManager = exhibitionLayoutManager
-        onViewRecyclerView.adapter = adapter
+        exhibitionSection.list.layoutManager = exhibitionLayoutManager
+        exhibitionSection.list.adapter = adapter
         viewModel.exhibitions
                 .bindToMain(adapter.itemChanges())
                 .disposedBy(disposeBag)
 
         /* Build event summary list*/
         val eventsLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
-        eventsRecyclerView.layoutManager = eventsLayoutManager
+        eventSection.list.layoutManager = eventsLayoutManager
         val eventsAdapter = WelcomeEventsAdapter()
-        eventsRecyclerView.adapter = eventsAdapter
+        eventSection.list.adapter = eventsAdapter
         viewModel.events
                 .bindToMain(eventsAdapter.itemChanges())
                 .disposedBy(disposeBag)
@@ -110,29 +113,34 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
     }
 
     override fun setupBindings(viewModel: WelcomeViewModel) {
-        toursSeeAllLink.clicks()
+
+        tourSection.label.text = resources.getString(R.string.tours)
+        exhibitionSection.label.text = resources.getString(R.string.onView)
+        eventSection.label.text = resources.getString(R.string.events)
+
+        tourSection.seeAllLink.clicks()
                 .defaultThrottle()
                 .subscribe { viewModel.onClickSeeAllTours() }
                 .disposedBy(disposeBag)
 
-        onViewLink.clicks()
+        exhibitionSection.seeAllLink.clicks()
                 .defaultThrottle()
                 .subscribe { viewModel.onClickSeeAllOnView() }
                 .disposedBy(disposeBag)
 
-        eventsLink.clicks()
+        eventSection.seeAllLink.clicks()
                 .defaultThrottle()
                 .subscribe { viewModel.onClickSeeAllEvents() }
                 .disposedBy(disposeBag)
 
-        val eventsAdapter = eventsRecyclerView.adapter as WelcomeEventsAdapter
+        val eventsAdapter = eventSection.list.adapter as WelcomeEventsAdapter
         eventsAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickEvent(pos, model.event)
                 }
                 .disposedBy(disposeBag)
 
-        val onViewAdapter = onViewRecyclerView.adapter as OnViewAdapter
+        val onViewAdapter = exhibitionSection.list.adapter as OnViewAdapter
         onViewAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickExhibition(pos, model.exhibition)
@@ -140,7 +148,7 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                 .disposedBy(disposeBag)
 
 
-        val toursAdapter = tourSummaryRecyclerView.adapter as WelcomeToursAdapter
+        val toursAdapter = tourSection.list.adapter as WelcomeToursAdapter
         toursAdapter.itemClicksWithPosition()
                 .subscribe { (pos, model) ->
                     viewModel.onClickTour(pos, model.tour)
@@ -220,9 +228,9 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                 .take(2)
                 .subscribe { it ->
                     if (it == 0L) {
-                        tourSummaryRecyclerView.smoothScrollToPosition(1)
+                        tourSection.list.smoothScrollToPosition(1)
                     } else {
-                        tourSummaryRecyclerView.smoothScrollToPosition(0)
+                        tourSection.list.smoothScrollToPosition(0)
                         viewModel.onPeekedTour()
                     }
                 }

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeFragment.kt
@@ -110,6 +110,18 @@ class WelcomeFragment : BaseViewModelFragment<WelcomeViewModel>() {
                     requestTitleUpdate(title)
                 }
                 .disposedBy(disposeBag)
+
+        viewModel.events
+                .map { it.isNotEmpty() }
+                .bindToMain(eventSection.visibility())
+                .disposedBy(disposeBag)
+
+        viewModel.exhibitions
+                .map { it.isNotEmpty() }
+                .observeOn(AndroidSchedulers.mainThread())
+                .bindToMain(exhibitionSection.visibility())
+                .disposedBy(disposeBag)
+
     }
 
     override fun setupBindings(viewModel: WelcomeViewModel) {

--- a/welcome/src/main/res/layout/fragment_welcome.xml
+++ b/welcome/src/main/res/layout/fragment_welcome.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/containerLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    android:id="@+id/containerLayout"
     tools:context="edu.artic.welcome.WelcomeFragment">
 
     <edu.artic.view.ArticMainAppBarLayout
@@ -15,7 +14,7 @@
         android:layout_height="wrap_content"
         app:backgroundImage="@drawable/dashboard"
         app:backgroundImagePadding="33dp"
-        app:icon="@drawable/tours"/>
+        app:icon="@drawable/tours" />
 
     <android.support.v4.widget.NestedScrollView
         android:id="@+id/content"
@@ -28,196 +27,64 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <View
-                android:id="@+id/topBg"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:background="@color/geyser"
-                android:orientation="vertical"
-                app:layout_constraintBottom_toTopOf="@id/tourSummaryLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_chainStyle="spread_inside"
-                />
-
             <TextView
                 android:id="@+id/welcomeMessage"
                 style="@style/BodySansSerifBlackCentered"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/marginActivitySubtitle"
-                android:layout_marginStart="@dimen/marginActivitySubtitle"
-                android:layout_marginTop="@dimen/marginDouble"
-                tools:text="Explore the museum with your personal, pocket-sized guide."
+                android:paddingStart="@dimen/marginActivitySubtitle"
+                android:paddingTop="@dimen/marginDouble"
+                android:paddingEnd="@dimen/marginActivitySubtitle"
+                android:background="@color/geyser"
                 app:layout_constraintBottom_toTopOf="@id/memberCardLink"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/topBg"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Explore the museum with your personal, pocket-sized guide." />
 
             <TextView
                 android:id="@+id/memberCardLink"
                 style="@style/BodyCtaTurquoise"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/marginDouble"
-                android:layout_marginEnd="@dimen/marginDouble"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
+                android:paddingBottom="@dimen/marginDouble"
+                android:paddingEnd="@dimen/marginDouble"
+                android:paddingStart="@dimen/marginDouble"
+                android:paddingTop="@dimen/marginDouble"
                 android:text="@string/accessYourMemberCard"
-                app:layout_constraintBottom_toBottomOf="@id/topBg"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/welcomeMessage"/>
+                android:background="@color/geyser"
+                app:layout_constraintTop_toBottomOf="@id/welcomeMessage" />
 
-
-            <TextView
-                android:id="@+id/tourSummaryLabel"
-                style="@style/SectionTitleBlack"
-                android:layout_width="wrap_content"
+            <include
+                android:id="@+id/tourSection"
+                layout="@layout/welcome_section"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:text="@string/tours"
-                app:layout_constraintBottom_toTopOf="@id/tourSummaryRecyclerView"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/topBg"/>
-
-            <TextView
-                android:id="@+id/toursSeeAllLink"
-                style="@style/SeeAll"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/seeAllLinkMargin"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:text="@string/seeAll"
-                app:layout_constraintBaseline_toBaselineOf="@id/tourSummaryLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintStart_toEndOf="@id/tourSummaryLabel"
-                app:layout_constraintWidth_default="wrap"
-                />
-
-            <android.support.v7.widget.RecyclerView
-                android:id="@+id/tourSummaryRecyclerView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:nestedScrollingEnabled="false"
-                android:paddingStart="@dimen/marginDouble"
-                android:paddingEnd="0dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/toursSeeAllLink"
-                tools:layoutManager="android.support.v7.widget.LinearLayoutManager"
-                tools:listitem="@layout/welcome_event_cell_layout"
-                tools:orientation="horizontal"/>
+                app:layout_constraintTop_toBottomOf="@id/memberCardLink" />
 
-            <View
-                android:id="@+id/tourDivider"
-                style="@style/divider"
-                android:layout_width="0dp"
-                android:layout_marginTop="@dimen/marginDouble"
+
+            <include
+                android:id="@+id/exhibitionSection"
+                layout="@layout/welcome_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tourSummaryRecyclerView"/>
+                app:layout_constraintTop_toBottomOf="@id/tourSection" />
 
-            <TextView
-                android:id="@+id/onViewLabel"
-                style="@style/SectionTitleBlack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/marginDouble"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:text="@string/onView"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tourDivider"/>
 
-            <TextView
-                android:id="@+id/onViewLink"
-                style="@style/SeeAll"
-                android:layout_width="0dp"
+            <include
+                android:id="@+id/eventSection"
+                layout="@layout/welcome_section"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/seeAllLinkMargin"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:text="@string/seeAll"
-                app:layout_constraintBaseline_toBaselineOf="@id/onViewLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintStart_toEndOf="@id/onViewLabel"
-                app:layout_constraintWidth_default="wrap"
-                />
-
-            <android.support.v7.widget.RecyclerView
-                android:id="@+id/onViewRecyclerView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:nestedScrollingEnabled="false"
-                android:paddingStart="@dimen/marginDouble"
-                android:paddingEnd="0dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/onViewLink"
-                tools:layoutManager="android.support.v7.widget.LinearLayoutManager"
-                tools:listitem="@layout/welcome_on_view_cell_layout"
-                tools:orientation="horizontal"/>
-
-            <View
-                android:id="@+id/onViewDivider"
-                style="@style/divider"
-                android:layout_width="0dp"
-                android:layout_marginTop="@dimen/marginDouble"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/onViewRecyclerView"/>
-
-            <TextView
-                android:id="@+id/eventLabel"
-                style="@style/SectionTitleBlack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/marginDouble"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:text="@string/events"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/onViewDivider"/>
-
-            <TextView
-                android:id="@+id/eventsLink"
-                style="@style/SeeAll"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/seeAllLinkMargin"
-                android:layout_marginStart="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:text="@string/seeAll"
-                app:layout_constraintBaseline_toBaselineOf="@id/eventLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintStart_toEndOf="@id/eventLabel"
-                app:layout_constraintWidth_default="wrap"
-                />
-
-            <android.support.v7.widget.RecyclerView
-                android:id="@+id/eventsRecyclerView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/marginDouble"
-                android:layout_marginTop="@dimen/marginDouble"
-                android:nestedScrollingEnabled="false"
-                android:paddingStart="@dimen/marginDouble"
-                android:paddingEnd="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/eventsLink"
-                tools:layoutManager="android.support.v7.widget.LinearLayoutManager"
-                tools:listitem="@layout/welcome_event_cell_layout"
-                tools:orientation="horizontal"/>
+                app:layout_constraintTop_toBottomOf="@id/exhibitionSection" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/welcome/src/main/res/layout/welcome_section.xml
+++ b/welcome/src/main/res/layout/welcome_section.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/label"
+        style="@style/SectionTitleBlack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginEnd="@dimen/marginDouble"
+        android:text="@string/onView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Label" />
+
+    <TextView
+        android:id="@+id/seeAllLink"
+        style="@style/SeeAll"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/marginDouble"
+        android:layout_marginEnd="@dimen/seeAllLinkMargin"
+        android:text="@string/seeAll"
+        app:layout_constraintBaseline_toBaselineOf="@id/label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/label"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_default="wrap" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/marginDouble"
+        android:layout_marginBottom="@dimen/marginDouble"
+        android:nestedScrollingEnabled="false"
+        android:paddingStart="@dimen/marginDouble"
+        android:paddingEnd="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/seeAllLink"
+        tools:layoutManager="android.support.v7.widget.LinearLayoutManager"
+        tools:listitem="@layout/welcome_on_view_cell_layout"
+        tools:orientation="horizontal" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/divider"
+        android:layout_width="0dp"
+        android:layout_marginTop="@dimen/marginDouble"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/list" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Follow-up to #339.

* Refactors welcome_fragment: Extracts repeating view into the `welcome_section` layout
* Hide event/exhibition section if associated data is missing.