### PR TITLE
Hides empty sections in audio player details : (AIC-617)

### DIFF
--- a/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
@@ -8,6 +8,7 @@ import android.support.design.widget.BottomNavigationView
 import android.support.v4.content.ContextCompat
 import android.support.v4.content.res.ResourcesCompat
 import android.view.MenuItem
+import android.view.View
 import android.widget.TextView
 import edu.artic.base.R
 
@@ -68,4 +69,15 @@ private object IgnoreReselection : BottomNavigationView.OnNavigationItemReselect
  */
 fun BottomNavigationView.preventReselection() {
     setOnNavigationItemReselectedListener(IgnoreReselection)
+}
+
+/**
+ * Function for showing/hiding the view.
+ */
+fun View.show(show: Boolean){
+    if (show) {
+        this.visibility = View.VISIBLE
+    } else {
+        this.visibility = View.GONE
+    }
 }

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -133,7 +133,16 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
         viewModel.authorCulturalPlace
                 .map { it.isNotEmpty() }
-                .bindToMain(artistCulturePlaceDenim.visibility())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeBy { hasData ->
+                    if (hasData) {
+                        artistCulturePlaceDenim.visibility = View.VISIBLE
+                        dividerBelowArtist.visibility = View.VISIBLE
+                    } else {
+                        artistCulturePlaceDenim.visibility = View.GONE
+                        dividerBelowArtist.visibility = View.GONE
+                    }
+                }
                 .disposedBy(disposeBag)
 
         viewModel.authorCulturalPlace

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -24,6 +24,7 @@ import edu.artic.adapter.*
 import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.asDeepLinkIntent
 import edu.artic.base.utils.filterHtmlEncodedText
+import edu.artic.base.utils.show
 import edu.artic.db.models.ArticTour
 import edu.artic.db.models.AudioFileModel
 import edu.artic.db.models.getIntroStop
@@ -135,13 +136,8 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 .map { it.isNotEmpty() }
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy { hasData ->
-                    if (hasData) {
-                        artistCulturePlaceDenim.visibility = View.VISIBLE
-                        dividerBelowArtist.visibility = View.VISIBLE
-                    } else {
-                        artistCulturePlaceDenim.visibility = View.GONE
-                        dividerBelowArtist.visibility = View.GONE
-                    }
+                    artistCulturePlaceDenim.show(show = hasData)
+                    dividerBelowArtist.show(show = hasData)
                 }
                 .disposedBy(disposeBag)
 
@@ -174,15 +170,13 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
         viewModel.relatedTours
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { tours ->
-                    if (tours.isEmpty()) {
-                        relatedTourTitle.visibility = View.GONE
-                        relatedToursView.visibility = View.GONE
-                        dividerBelowRelatedTours.visibility = View.GONE
-                    } else {
+                    val hasData = tours.isNotEmpty()
+                    relatedTourTitle.show(show = hasData)
+                    relatedToursView.show(show = hasData)
+                    dividerBelowRelatedTours.show(show = hasData)
+
+                    if (hasData) {
                         relatedToursView.removeAllViews()
-                        relatedTourTitle.visibility = View.VISIBLE
-                        relatedToursView.visibility = View.VISIBLE
-                        dividerBelowRelatedTours.visibility = View.VISIBLE
                         addRelatedToursToView(tours)
                     }
                 }

--- a/media_ui/src/main/res/layout/fragment_audio_details.xml
+++ b/media_ui/src/main/res/layout/fragment_audio_details.xml
@@ -142,6 +142,7 @@
                 android:layout_marginStart="@dimen/marginDouble"
                 android:layout_marginTop="@dimen/marginDouble"
                 android:layout_marginEnd="@dimen/marginDouble"
+                android:visibility="gone"
                 android:text="@string/relatedTours"
                 tools:text="@string/relatedTours" />
 
@@ -149,12 +150,14 @@
                 android:id="@+id/relatedToursView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 android:orientation="vertical" />
 
             <View
                 android:id="@+id/dividerBelowRelatedTours"
                 style="@style/dividerTwentyOpaque"
                 android:layout_width="match_parent"
+                android:visibility="gone"
                 android:layout_marginTop="@dimen/marginQuad" />
 
             <edu.artic.view.DropdownTextView

--- a/media_ui/src/main/res/layout/fragment_audio_details.xml
+++ b/media_ui/src/main/res/layout/fragment_audio_details.xml
@@ -128,10 +128,13 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/marginDouble"
                 android:includeFontPadding="false"
+                android:visibility="gone"
                 tools:text="Edward hooper" />
 
             <View
+                android:id="@+id/dividerBelowArtist"
                 style="@style/dividerTwentyOpaque"
+                android:visibility="gone"
                 android:layout_width="match_parent" />
 
             <TextView


### PR DESCRIPTION
When there is no data for `related tours` & `artist culture place`, this PR hides those sections from `audio details screen`.