### PR TITLE
Shrink Main App Bars' title text (AIC-593)

### DIFF
--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
@@ -26,11 +26,23 @@
     </style>
 
     <style name="PageTitleLargeWhite" parent="TextAppearance.AppCompat.Title">
+        <!--
+        Base style for the largest text on-screen. Callers should generally be aware
+        of the `PageTitleLargeWhite.FixedSize` variant too.
+         -->
         <item name="android:fontFamily">@font/ideal_sans_medium</item>
         <item name="android:gravity">center_horizontal</item>
         <item name="android:textSize">40sp</item>
         <item name="android:letterSpacing">0.03</item>
         <item name="android:lineSpacingExtra">0sp</item>
+    </style>
+
+    <style name="PageTitleLargeWhite.FixedSize">
+        <!--
+        With large text, scaling is not always desirable. Use this style
+        instead of `PageTitleLargeWhite` if that is so.
+        -->
+        <item name="android:textSize" tools:ignore="SpUsage">35dp</item>
     </style>
 
     <style name="Widget.AppCompat.Toolbar.Ideal">

--- a/info/src/main/res/layout/fragment_information.xml
+++ b/info/src/main/res/layout/fragment_information.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         app:backgroundImage="@drawable/info_image"
         app:expandedTitleStyle="@style/InformationExpandedTitle"
+        app:expandedFixedSizeTitleStyle="@style/InformationExpandedTitle"
         app:icon="@drawable/ic_info" />
 
     <android.support.v4.widget.NestedScrollView

--- a/info/src/main/res/values/styles.xml
+++ b/info/src/main/res/values/styles.xml
@@ -30,12 +30,8 @@
     </style>
 
 
-    <style name="InformationExpandedTitle" parent="TextAppearance.AppCompat.Title">
-        <item name="android:fontFamily">@font/ideal_sans_medium</item>
-        <item name="android:gravity">center_horizontal</item>
+    <style name="InformationExpandedTitle" parent="PageTitleLargeWhite">
         <item name="android:textSize">@dimen/textPageTitle</item>
-        <item name="android:letterSpacing">0.03</item>
-        <item name="android:lineSpacingExtra">0sp</item>
     </style>
 
     <style name="InfoMenu" parent="CardTitleLargeBlack">

--- a/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
+++ b/ui/src/main/kotlin/edu/artic/ui/BaseFragment.kt
@@ -18,6 +18,7 @@ import edu.artic.analytics.AnalyticsTracker
 import edu.artic.analytics.ScreenName
 import edu.artic.base.utils.getThemeColors
 import edu.artic.base.utils.setWindowFlag
+import edu.artic.view.ArticMainAppBarLayout
 import javax.inject.Inject
 
 
@@ -57,7 +58,14 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
              * Ensure [toolbar] and [collapsingToolbar] have had a chance to be bound
              */
             updateToolbar(requireView())
-            collapsingToolbar?.title = proposedTitle
+            collapsingToolbar?.run {
+                title = proposedTitle
+                parent.let {
+                    if (it is ArticMainAppBarLayout) {
+                        it.adaptExpandedTextAppearance()
+                    }
+                }
+            }
         }
     }
 
@@ -149,10 +157,10 @@ abstract class BaseFragment : DialogFragment(), OnBackPressedListener {
         }
 
         collapsingToolbar = view.findViewById(R.id.collapsingToolbar)
-        collapsingToolbar?.apply {
-            val toolbarTextTypeFace = ResourcesCompat.getFont(requireContext(), R.font.ideal_sans_medium)
-            setCollapsedTitleTypeface(toolbarTextTypeFace)
-            setExpandedTitleTypeface(toolbarTextTypeFace)
+        collapsingToolbar?.parent?.let {
+            if (it is ArticMainAppBarLayout) {
+                it.adaptExpandedTextAppearance()
+            }
         }
 
     }

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -1,9 +1,11 @@
 package edu.artic.view
 
 import android.content.Context
+import android.graphics.Typeface
 import android.support.annotation.DrawableRes
 import android.support.annotation.StyleRes
 import android.support.design.widget.AppBarLayout
+import android.support.v4.content.res.ResourcesCompat
 import android.util.AttributeSet
 import android.view.View
 import com.fuzz.rx.DisposeBag
@@ -26,6 +28,7 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
     private val expandedFixedSizeTextAppearance: Int
 
     private var clickConsumer: Consumer<Unit>? = null
+    private var expandedTypeface: Typeface? = null
 
     init {
         View.inflate(context, R.layout.view_app_bar_layout, this)
@@ -58,6 +61,7 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
             subTitle.text =  a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
         }
 
+        expandedTypeface = ResourcesCompat.getFont(context, R.font.ideal_sans_medium)
         expandedDefaultTextAppearance = expandedDefaultAppearance
         expandedFixedSizeTextAppearance = expandedFixedSizeAppearance
 

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -28,6 +28,8 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
         View.inflate(context, R.layout.view_app_bar_layout, this)
         fitsSystemWindows = true
 
+        var expandedDefaultAppearance: Int = R.style.PageTitleLargeWhite
+
         if (attrs != null) {
             val a = context.theme.obtainStyledAttributes(
                     attrs,
@@ -39,16 +41,16 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
             setBackgroundImagePadding(a.getDimension(R.styleable.ArticMainAppBarLayout_backgroundImagePadding, 0f))
             subTitle.text = a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
 
-            expandedDefaultTextStyleAttribute = a.getResourceId(
+            expandedDefaultAppearance = a.getResourceId(
                     R.styleable.ArticMainAppBarLayout_expandedTitleStyle,
-                    R.style.PageTitleLargeWhite
+                    expandedDefaultAppearance
             )
 
-            collapsingToolbar.setExpandedTitleTextAppearance(expandedDefaultTextStyleAttribute)
+            collapsingToolbar.setExpandedTitleTextAppearance(expandedDefaultAppearance)
             subTitle.text =  a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
-        } else {
-            expandedDefaultTextStyleAttribute = R.style.PageTitleLargeWhite
         }
+
+        expandedDefaultTextStyleAttribute = expandedDefaultAppearance
 
         // update our content when offset changes.
         addOnOffsetChangedListener(OnOffsetChangedListener { aBarLayout, verticalOffset ->

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -124,8 +124,27 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
     @UiThread
     fun adaptExpandedTextAppearance() {
         collapsingToolbar.run {
+            val titleLength = title?.toString().orEmpty().length
+
+            if (titleLength < FULL_SIZE_TEXT_BREAKPOINT) {
+                setExpandedTitleTextAppearance(expandedDefaultTextAppearance)
+            } else {
+                setExpandedTitleTextAppearance(expandedFixedSizeTextAppearance)
+            }
             setExpandedTitleTypeface(expandedTypeface)
         }
+    }
+
+
+    companion object {
+
+        /**
+         * Max length of text visible with expanded style [expandedDefaultTextAppearance].
+         *
+         * If title extends beyond this, callers should switch
+         * [collapsingToolbar] over to [expandedFixedSizeTextAppearance].
+         */
+        const val FULL_SIZE_TEXT_BREAKPOINT: Int = """Welcome, And…""".length
     }
 
 }

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -2,6 +2,7 @@ package edu.artic.view
 
 import android.content.Context
 import android.support.annotation.DrawableRes
+import android.support.annotation.StyleRes
 import android.support.design.widget.AppBarLayout
 import android.util.AttributeSet
 import android.view.View
@@ -19,6 +20,8 @@ import kotlinx.android.synthetic.main.view_app_bar_layout.view.*
  */
 class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : AppBarLayout(context, attrs) {
     private val disposeBag: DisposeBag = DisposeBag()
+    @StyleRes
+    private val expandedDefaultTextStyleAttribute: Int
     private var clickConsumer: Consumer<Unit>? = null
 
     init {
@@ -35,11 +38,16 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
             setBackgroundImage(a.getResourceId(R.styleable.ArticMainAppBarLayout_backgroundImage, 0))
             setBackgroundImagePadding(a.getDimension(R.styleable.ArticMainAppBarLayout_backgroundImagePadding, 0f))
             subTitle.text = a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
-            val setExpandedTitleTextAppearance = a.getResourceId(
+
+            expandedDefaultTextStyleAttribute = a.getResourceId(
                     R.styleable.ArticMainAppBarLayout_expandedTitleStyle,
-                    R.style.PageTitleLargeWhite)
-            collapsingToolbar.setExpandedTitleTextAppearance(setExpandedTitleTextAppearance)
+                    R.style.PageTitleLargeWhite
+            )
+
+            collapsingToolbar.setExpandedTitleTextAppearance(expandedDefaultTextStyleAttribute)
             subTitle.text =  a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
+        } else {
+            expandedDefaultTextStyleAttribute = R.style.PageTitleLargeWhite
         }
 
         // update our content when offset changes.

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -21,7 +21,10 @@ import kotlinx.android.synthetic.main.view_app_bar_layout.view.*
 class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : AppBarLayout(context, attrs) {
     private val disposeBag: DisposeBag = DisposeBag()
     @StyleRes
-    private val expandedDefaultTextStyleAttribute: Int
+    private val expandedDefaultTextAppearance: Int
+    @StyleRes
+    private val expandedFixedSizeTextAppearance: Int
+
     private var clickConsumer: Consumer<Unit>? = null
 
     init {
@@ -29,6 +32,7 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
         fitsSystemWindows = true
 
         var expandedDefaultAppearance: Int = R.style.PageTitleLargeWhite
+        var expandedFixedSizeAppearance: Int = R.style.PageTitleLargeWhite_FixedSize
 
         if (attrs != null) {
             val a = context.theme.obtainStyledAttributes(
@@ -45,12 +49,17 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
                     R.styleable.ArticMainAppBarLayout_expandedTitleStyle,
                     expandedDefaultAppearance
             )
+            expandedFixedSizeAppearance = a.getResourceId(
+                    R.styleable.ArticMainAppBarLayout_expandedFixedSizeTitleStyle,
+                    expandedFixedSizeAppearance
+            )
 
             collapsingToolbar.setExpandedTitleTextAppearance(expandedDefaultAppearance)
             subTitle.text =  a.getString(R.styleable.ArticMainAppBarLayout_subtitle)
         }
 
-        expandedDefaultTextStyleAttribute = expandedDefaultAppearance
+        expandedDefaultTextAppearance = expandedDefaultAppearance
+        expandedFixedSizeTextAppearance = expandedFixedSizeAppearance
 
         // update our content when offset changes.
         addOnOffsetChangedListener(OnOffsetChangedListener { aBarLayout, verticalOffset ->

--- a/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
+++ b/ui/src/main/kotlin/edu/artic/view/ArticMainAppBarLayout.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Typeface
 import android.support.annotation.DrawableRes
 import android.support.annotation.StyleRes
+import android.support.annotation.UiThread
 import android.support.design.widget.AppBarLayout
 import android.support.v4.content.res.ResourcesCompat
 import android.util.AttributeSet
@@ -118,6 +119,13 @@ class ArticMainAppBarLayout(context: Context, attrs: AttributeSet? = null) : App
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         disposeBag.clear()
+    }
+
+    @UiThread
+    fun adaptExpandedTextAppearance() {
+        collapsingToolbar.run {
+            setExpandedTitleTypeface(expandedTypeface)
+        }
     }
 
 }

--- a/ui/src/main/res/layout/view_app_bar_layout.xml
+++ b/ui/src/main/res/layout/view_app_bar_layout.xml
@@ -14,7 +14,6 @@
         android:fitsSystemWindows="true"
         app:contentScrim="?attr/colorPrimary"
         app:expandedTitleGravity="bottom|center_horizontal"
-        app:expandedTitleTextAppearance="@style/PageTitleLargeWhite"
         app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
         <FrameLayout

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -20,10 +20,14 @@
 
     <declare-styleable name="ArticMainAppBarLayout">
         <attr name="icon" format="reference"/>
+
         <attr name="backgroundImage" format="reference"/>
         <attr name="backgroundImagePadding" format="dimension"/>
+
         <attr name="subtitle" format="string"/>
+
         <attr name="expandedTitleStyle" format="reference"/>
+        <attr name="expandedFixedSizeTitleStyle" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="DetailButton">


### PR DESCRIPTION
It is easy for a device with over 400 horizontal DPI (such as the Galaxy S8 or the Pixel 2) to not have enough space for the `Welcome` message we show to signed-in users.

The issue is slightly complicated by the `CollapsingToolbarLayout` (henceforth `CLT`) widget we've used on that screen, as it does not support the auto-size functionality available in e.g. standard `AppCompatTextView`s. For this reason, then, we needed to tie along the logic for changing the `CLT`'s size with that for changing its title.

This PR introduces a new layout attribute, a new style, and some extra calls to `ArticMainAppBarLayout` to handle the changeoff. Also of note: we need to re-establish the typeface in use on the `CTL` every time the style changes. I am not yet certain as to whether this is a bug in my code, but currently lean towards 'no'.