### PR TITLE
Allows optional data in json blob

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -148,8 +148,12 @@ class AppDataManager @Inject constructor(
                                 articMapFloorDao.insertMapFloors(floors.toList())
                             }
 
-                            val galleries : List<ArticGallery> = result.galleries?.values?.toList()?.filterNotNull().orEmpty()
-                            if (galleries.isNotEmpty()) {
+                            val rawGalleries : List<ArticGallery?>? = result.galleries
+                                    ?.values
+                                    ?.toList()
+
+                            val galleries = rawGalleries?.filterNotNull().orEmpty()
+                            if (rawGalleries?.isNotEmpty() == true) {
                                 galleryDao.clear()
                                 galleryDao.addGalleries(galleries)
                             }

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -140,8 +140,9 @@ class AppDataManager @Inject constructor(
                         // runs the whole operation in a transaction.
                         appDatabase.runInTransaction {
                             val result = appDataState.result as ArticAppData
-
-                            dashboardDao.setDashBoard(result.dashboard)
+                            result.dashboard?.let { dashboard ->
+                                dashboardDao.setDashBoard(dashboard)
+                            }
                             generalInfoDao.setGeneralInfo(result.generalInfo)
                             result.mapFloors?.values?.let { floors ->
                                 articMapFloorDao.insertMapFloors(floors.toList())

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -166,22 +166,7 @@ class AppDataManager @Inject constructor(
 
                             val objects = result.objects
                             if (objects?.isNotEmpty() == true) {
-                                objects.values.filterNotNull().forEach { articObject ->
-                                    // add a floor field to the object, since its not known in the JSON directly.
-                                    rawGalleries
-                                            ?.asSequence()
-                                            ?.filterNotNull()
-                                            ?.firstOrNull { it.title == articObject.galleryLocation }
-                                            ?.let { gallery ->
-                                                articObject.floor = gallery.floor
-                                            }
-
-                                    articObject.audioCommentary.forEach { audioCommentaryObject ->
-                                        audioCommentaryObject.audio?.let {
-                                            audioCommentaryObject.audioFile = audioFileDao.getAudioById(it)
-                                        }
-                                    }
-                                }
+                                updateArticObjects(objects, rawGalleries)
                                 objectDao.clear()
                                 objectDao.addObjects(objects.values.filterNotNull().toList())
                             }
@@ -223,6 +208,25 @@ class AppDataManager @Inject constructor(
                     }
                     return@flatMap appDataState.asObservable()
                 }
+    }
+
+    private fun updateArticObjects(objects: Map<String, ArticObject?>, rawGalleries: List<ArticGallery?>?) {
+        objects.values.filterNotNull().forEach { articObject ->
+            // add a floor field to the object, since its not known in the JSON directly.
+            rawGalleries
+                    ?.asSequence()
+                    ?.filterNotNull()
+                    ?.firstOrNull { it.title == articObject.galleryLocation }
+                    ?.let { gallery ->
+                        articObject.floor = gallery.floor
+                    }
+
+            articObject.audioCommentary.forEach { audioCommentaryObject ->
+                audioCommentaryObject.audio?.let {
+                    audioCommentaryObject.audioFile = audioFileDao.getAudioById(it)
+                }
+            }
+        }
     }
 
     private fun updateTours(it: List<ArticTour?>, objects: Map<String, ArticObject?>?) {

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -144,12 +144,12 @@ class AppDataManager @Inject constructor(
                                 dashboardDao.setDashBoard(dashboard)
                             }
                             generalInfoDao.setGeneralInfo(result.generalInfo)
-                            result.mapFloors?.values?.let { floors ->
+                            result.mapFloors.values.filterNotNull().let { floors ->
                                 articMapFloorDao.insertMapFloors(floors.toList())
                             }
 
-                            val galleries = result.galleries?.values?.toList()
-                            if (galleries?.isNotEmpty() == true) {
+                            val galleries : List<ArticGallery> = result.galleries?.values?.toList()?.filterNotNull().orEmpty()
+                            if (galleries.isNotEmpty()) {
                                 galleryDao.clear()
                                 galleryDao.addGalleries(galleries)
                             }
@@ -157,7 +157,7 @@ class AppDataManager @Inject constructor(
                             val audioFiles = result.audioFiles
                             if (audioFiles?.isNotEmpty() == true) {
                                 audioFileDao.clear()
-                                audioFileDao.addAudioFiles(audioFiles.values.toList())
+                                audioFileDao.addAudioFiles(audioFiles.values.filterNotNull().toList())
                             }
 
                             val objects = result.objects

--- a/db/src/main/kotlin/edu/artic/db/DefaultOnDataMismatchAdapter.java
+++ b/db/src/main/kotlin/edu/artic/db/DefaultOnDataMismatchAdapter.java
@@ -1,0 +1,70 @@
+package edu.artic.db;
+
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+public final class DefaultOnDataMismatchAdapter<T> extends JsonAdapter<T> {
+    private final JsonAdapter<T> delegate;
+    private final T defaultValue;
+
+    private DefaultOnDataMismatchAdapter(JsonAdapter<T> delegate, T defaultValue) {
+        this.delegate = delegate;
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public T fromJson(JsonReader reader) throws IOException {
+        // Read the value first so that the reader will be in a known state even if there's an
+        // exception. Otherwise it may be awkward to recover: it might be between calls to
+        // beginObject() and endObject() for example.
+        Object jsonValue = reader.readJsonValue();
+
+        // Use the delegate to convert the JSON value to the target type.
+        try {
+            return delegate.fromJsonValue(jsonValue);
+        } catch (JsonDataException e) {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, T value) throws IOException {
+        delegate.toJson(writer, value);
+    }
+
+    public static <T> Factory newFactory(final Class<T> type, final T defaultValue) {
+        return new Factory() {
+            @Override
+            public JsonAdapter<?> create(
+                    Type requestedType, Set<? extends Annotation> annotations, Moshi moshi) {
+                if (type != requestedType) return null;
+                JsonAdapter<T> delegate = moshi.nextAdapter(this, type, annotations);
+                return new DefaultOnDataMismatchAdapter<>(delegate, defaultValue);
+            }
+        };
+    }
+}

--- a/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
+++ b/db/src/main/kotlin/edu/artic/db/MoshiAdapters.kt
@@ -7,6 +7,7 @@ import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import edu.artic.db.models.*
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.DateTimeFormatter.ISO_DATE_TIME
@@ -23,6 +24,15 @@ fun Moshi.Builder.registerAdapters() = apply {
     add(KotlinJsonAdapterFactory())
     add(NullPrimitiveAdapter())
     add(ZonedDateTimeAdapter())
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticGallery::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticObject::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticAudioFile::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticMapAnnotation::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(DashBoard::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticMapFloor::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticTourCategory::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticTour::class.java, null))
+    add(DefaultOnDataMismatchAdapter.newFactory(ArticExhibitionCMS::class.java, null))
     add(FloorAdapter())
 }
 

--- a/db/src/main/kotlin/edu/artic/db/models/ArticAppData.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticAppData.kt
@@ -7,16 +7,16 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ArticAppData(
-        @Json(name = "dashboard") val dashboard: DashBoard,
+        @Json(name = "dashboard") val dashboard: DashBoard?,
         @Json(name = "general_info") val generalInfo: ArticGeneralInfo,
-        @Json(name = "galleries") val galleries: Map<String, ArticGallery>?,
-        @Json(name = "objects") val objects: Map<String, ArticObject>?,
-        @Json(name = "audio_files") val audioFiles: Map<String, ArticAudioFile>?,
-        @Json(name = "tours") val tours: List<ArticTour>?,
-        @Json(name = "map_annontations") val mapAnnotations: Map<String, ArticMapAnnotation>?,
+        @Json(name = "galleries") val galleries: Map<String, ArticGallery?>?,
+        @Json(name = "objects") val objects: Map<String, ArticObject?>?,
+        @Json(name = "audio_files") val audioFiles: Map<String, ArticAudioFile?>?,
+        @Json(name = "tours") val tours: List<ArticTour?>?,
+        @Json(name = "map_annontations") val mapAnnotations: Map<String, ArticMapAnnotation?>?,
         @Json(name = "map_floors") val mapFloors: Map<String, ArticMapFloor>,
-        @Json(name = "tour_categories") val tourCategories: Map<String, ArticTourCategory>?,
-        @Json(name = "exhibitions") val exhibitions: List<ArticExhibitionCMS>?,
+        @Json(name = "tour_categories") val tourCategories: Map<String, ArticTourCategory?>?,
+        @Json(name = "exhibitions") val exhibitions: List<ArticExhibitionCMS?>?,
         @Json(name = "data") val data: ArticDataObject,
         @Json(name = "search") val search: ArticSearchObject?
 )

--- a/db/src/main/kotlin/edu/artic/db/models/ArticAppData.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticAppData.kt
@@ -14,7 +14,7 @@ data class ArticAppData(
         @Json(name = "audio_files") val audioFiles: Map<String, ArticAudioFile?>?,
         @Json(name = "tours") val tours: List<ArticTour?>?,
         @Json(name = "map_annontations") val mapAnnotations: Map<String, ArticMapAnnotation?>?,
-        @Json(name = "map_floors") val mapFloors: Map<String, ArticMapFloor>,
+        @Json(name = "map_floors") val mapFloors: Map<String, ArticMapFloor?>,
         @Json(name = "tour_categories") val tourCategories: Map<String, ArticTourCategory?>?,
         @Json(name = "exhibitions") val exhibitions: List<ArticExhibitionCMS?>?,
         @Json(name = "data") val data: ArticDataObject,


### PR DESCRIPTION
Basically, this PR replaces malformed data by null and then discards null values while updating the database. 

Handles malformed `ArticGallery, ArticObject, ArticAudioFile,ArticMapAnnotation, DashBoard, ArticMapFloor, ArticTourCategory, ArticTour, ArticExhibitionCMS` objects by adding `DefaultOnDataMismatchAdapter` for each of objects mentioned above.