### PR TITLE
Search: Fixes the spacing issue between suggested artworks (AIC-633)

### DIFF
--- a/search/src/main/java/edu/artic/search/CircularViewItemDecoration.kt
+++ b/search/src/main/java/edu/artic/search/CircularViewItemDecoration.kt
@@ -25,12 +25,12 @@ class CircularViewItemDecoration(private val currentPadding: Int,
                 }.disposedBy(disposeBag)
             } else if (onTheMapPosition > 0) {
                 if (it is SearchCircularCellViewModel || it is SearchAmenitiesCellViewModel) {
-                    val offsetPositionFromOnTheMap = position - (onTheMapPosition+1)
-                    val spannedPosition = offsetPositionFromOnTheMap % SearchResultsAdapter.MAX_ARTWORKS_PER_ROW
-                    val middlePadding = finalPadding-currentPadding
+                    val offsetPositionFromOnTheMap = position - (onTheMapPosition + 1)
+                    val artworkColumn = offsetPositionFromOnTheMap % SearchResultsAdapter.MAX_ARTWORKS_PER_ROW
+                    val middlePadding = finalPadding - currentPadding
                     when {
-                        spannedPosition > 0 -> {
-                            outRect.left = middlePadding*spannedPosition
+                        artworkColumn > 0 -> {
+                            outRect.left = middlePadding * artworkColumn
                             outRect.right = 0
                         }
                         else -> {

--- a/search/src/main/java/edu/artic/search/CircularViewItemDecoration.kt
+++ b/search/src/main/java/edu/artic/search/CircularViewItemDecoration.kt
@@ -3,48 +3,30 @@ package edu.artic.search
 import android.graphics.Rect
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import com.fuzz.rx.DisposeBag
-import com.fuzz.rx.disposedBy
 
 class CircularViewItemDecoration(private val currentPadding: Int,
-                                 private val finalPadding: Int,
-                                 private val disposeBag: DisposeBag) : RecyclerView.ItemDecoration() {
-
-    private var onTheMapPosition = 0
+                                 private val finalPadding: Int
+) : RecyclerView.ItemDecoration() {
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         val position = parent.getChildAdapterPosition(view)
         val adapter = parent.adapter as SearchResultsAdapter
 
         adapter.getItemOrNull(position)?.let {
-            if (it is SearchTextHeaderViewModel) {
-                it.text.subscribe {
-                    if (it == R.string.on_the_map) {
-                        onTheMapPosition = position
+            if (it is OrderedCellViewModel && it.order > -1) {
+                val artworkColumn = it.order % SearchResultsAdapter.MAX_ARTWORKS_PER_ROW
+                val middlePadding = finalPadding - currentPadding
+                when {
+                    artworkColumn > 0 -> {
+                        outRect.left = middlePadding * artworkColumn
+                        outRect.right = 0
                     }
-                }.disposedBy(disposeBag)
-            } else if (onTheMapPosition > 0) {
-                if (it is SearchCircularCellViewModel || it is SearchAmenitiesCellViewModel) {
-                    val offsetPositionFromOnTheMap = position - (onTheMapPosition + 1)
-                    val artworkColumn = offsetPositionFromOnTheMap % SearchResultsAdapter.MAX_ARTWORKS_PER_ROW
-                    val middlePadding = finalPadding - currentPadding
-                    when {
-                        artworkColumn > 0 -> {
-                            outRect.left = middlePadding * artworkColumn
-                            outRect.right = 0
-                        }
-                        else -> {
-                            outRect.left = 0
-                            outRect.right = 0
-                        }
+                    else -> {
+                        outRect.left = 0
+                        outRect.right = 0
                     }
-                } else {
-
                 }
-            } else {
-
             }
         }
     }
-
 }

--- a/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
+++ b/search/src/main/java/edu/artic/search/DefaultSearchSuggestionsViewModel.kt
@@ -29,10 +29,10 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
 
     private fun getAmenitiesViewModels(): List<SearchBaseCellViewModel> {
         return listOf(
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop),
-                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms))
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining, 0),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge, 1),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop, 2),
+                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms, 3))
     }
 
     init {
@@ -50,8 +50,8 @@ class DefaultSearchSuggestionsViewModel @Inject constructor(searchSuggestionsDao
 
         getSuggestedArtworks(searchSuggestionsDao, objectDao)
                 .map { objects ->
-                    objects.map { artwork ->
-                        SearchCircularCellViewModel(artwork)
+                    objects.mapIndexed { index, articObject ->
+                        SearchCircularCellViewModel(articObject, index)
                     }
                 }
                 .bindTo(suggestedArtworks)

--- a/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
+++ b/search/src/main/java/edu/artic/search/SearchBaseFragment.kt
@@ -62,7 +62,7 @@ abstract class SearchBaseFragment<TViewModel : SearchBaseViewModel> : BaseViewMo
             adapter = SearchResultsAdapter()
             layoutManager = lm
             addItemDecoration(SearchDividerItemDecoration(this.context))
-            addItemDecoration(CircularViewItemDecoration(endCurrentPadding, endFinalPadding, disposeBag))
+            addItemDecoration(CircularViewItemDecoration(endCurrentPadding, endFinalPadding))
         }
 
     }

--- a/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
@@ -86,7 +86,7 @@ class SearchTourCellViewModel(val articTour: ArticTour) : SearchBaseListItemView
  * ViewModel for displaying the circular artwork image under "On the map" section.
  */
 class SearchCircularCellViewModel(val artwork: ArticObject?,
-                                  override val order: Int = -1) : SearchBaseCellViewModel(), OrderedCellViewModel {
+                                  override val order: Int) : SearchBaseCellViewModel(), OrderedCellViewModel {
 
     val imageUrl: Subject<String> = BehaviorSubject.createDefault(
             artwork?.thumbUrl.orEmpty()
@@ -99,7 +99,7 @@ class SearchCircularCellViewModel(val artwork: ArticObject?,
 class SearchAmenitiesCellViewModel(
         @DrawableRes val value: Int,
         val type: SuggestedMapAmenities,
-        override val order: Int = -1
+        override val order: Int
 ) : SearchBaseCellViewModel(), OrderedCellViewModel
 
 

--- a/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultCellViewModels.kt
@@ -85,7 +85,8 @@ class SearchTourCellViewModel(val articTour: ArticTour) : SearchBaseListItemView
 /**
  * ViewModel for displaying the circular artwork image under "On the map" section.
  */
-class SearchCircularCellViewModel(val artwork: ArticObject?) : SearchBaseCellViewModel() {
+class SearchCircularCellViewModel(val artwork: ArticObject?,
+                                  override val order: Int = -1) : SearchBaseCellViewModel(), OrderedCellViewModel {
 
     val imageUrl: Subject<String> = BehaviorSubject.createDefault(
             artwork?.thumbUrl.orEmpty()
@@ -95,8 +96,11 @@ class SearchCircularCellViewModel(val artwork: ArticObject?) : SearchBaseCellVie
 /**
  * ViewModel for displaying the amenities icons
  */
-class SearchAmenitiesCellViewModel(@DrawableRes val value: Int, val type: SuggestedMapAmenities) : SearchBaseCellViewModel()
-
+class SearchAmenitiesCellViewModel(
+        @DrawableRes val value: Int,
+        val type: SuggestedMapAmenities,
+        override val order: Int = -1
+) : SearchBaseCellViewModel(), OrderedCellViewModel
 
 
 /**
@@ -113,4 +117,8 @@ sealed class Header(@StringRes val title : Int) {
     class Artworks(title: Int = R.string.artworks) : Header(title)
     class Tours(title: Int = R.string.tours) : Header(title)
     class Exhibitions(title: Int = R.string.exhibitions) : Header(title)
+}
+
+interface OrderedCellViewModel {
+    open val order: Int
 }

--- a/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
+++ b/search/src/main/java/edu/artic/search/SearchSuggestedViewModel.kt
@@ -40,14 +40,14 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
                 .combineLatest(
                         dynamicCells,
                         Observable.just(listOf(
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop),
-                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restaurant, SuggestedMapAmenities.Dining, 0),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_lounge, SuggestedMapAmenities.MembersLounge, 1),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_shop, SuggestedMapAmenities.GiftShop, 2),
+                                SearchAmenitiesCellViewModel(R.drawable.ic_icon_amenity_map_restroom, SuggestedMapAmenities.Restrooms, 3),
                                 /**
                                  * TODO:: Refactor it, used something other than SearchAmenitiesCellViewModel (maybe PaddingAmenitiesCellViewModel)
                                  * **/
-                                SearchAmenitiesCellViewModel(0,SuggestedMapAmenities.Restrooms))
+                                SearchAmenitiesCellViewModel(0, SuggestedMapAmenities.Restrooms, 4))
                         ),
                         suggestedArtworks)
                 { dynamicCells, amenities, suggestedArtworks ->
@@ -66,8 +66,8 @@ class SearchSuggestedViewModel @Inject constructor(private val manager: SearchRe
     private fun setupOnMapSuggestionsBind() {
         getSuggestedArtworks(searchSuggestionsDao, objectDao)
                 .map { objects ->
-                    objects.map {
-                        SearchCircularCellViewModel(it)
+                    objects.mapIndexed { index, item ->
+                        SearchCircularCellViewModel(item, index)
                     }
                 }
                 .bindTo(suggestedArtworks)


### PR DESCRIPTION
The cause behind this issue was the logic we used to get column number for suggested artworks. That logic was based on the position of the `on the map` cell.

```
val columnValue = (currentPosition - onTheMapPosition) % maxSize
```

This logic can go wrong when suggested artwork cells are recycled before that `on the map` cell. So the proposed solution is to not use `on the map` cell at all. Now I pass the order of the cells when they are constructed and then use it to calculate the column index. 

```
val columnValue = viewModel.order % maxSize
```
