### PR TITLE
Display object's credit line when available : AIC-646

### DIFF
--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -180,7 +180,10 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
         viewModel.credits
                 .map { it.isNotEmpty() }
-                .bindToMain(credit.visibility())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeBy {
+                    credit.show(it)
+                }
                 .disposedBy(disposeBag)
 
 

--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsFragment.kt
@@ -148,12 +148,14 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
         viewModel.transcript
                 .map { it.isNotEmpty() }
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy {
                     transcript.show(it)
                 }
                 .disposedBy(disposeBag)
 
         viewModel.transcript
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     transcript.setContentText(it.filterHtmlEncodedText())
                 }.disposedBy(disposeBag)
@@ -164,6 +166,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.tourDescription
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     tourDescription.text = it.filterHtmlEncodedText()
                 }.disposedBy(disposeBag)
@@ -174,6 +177,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
                 .disposedBy(disposeBag)
 
         viewModel.tourIntroduction
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     tourIntroduction.text = it.filterHtmlEncodedText()
                 }.disposedBy(disposeBag)
@@ -188,6 +192,7 @@ class AudioDetailsFragment : BaseViewModelFragment<AudioDetailsViewModel>() {
 
 
         viewModel.credits
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     credit.setContentText(it.filterHtmlEncodedText())
                 }.disposedBy(disposeBag)


### PR DESCRIPTION
```
     viewModel.credits
                .map { it.isNotEmpty() }
                .bindToMain(credit.visibility())
                .disposedBy(disposeBag)
```
Above subscription was not working properly. Instead of using`bindToMain` operator, subscribing and updating view's visibility worked. 

```
        viewModel.credits
                .map { it.isNotEmpty() }
                .observeOn(AndroidSchedulers.mainThread())
                .subscribeBy {
                    credit.show(it)
                }
                .disposedBy(disposeBag)
```

Also, I have made sure to update the view's properties in main thread by adding `              .observeOn(AndroidSchedulers.mainThread())` wherever it was missing. 

