### PR TITLE
Manually hide transcript & credit views on Tours' Audio Details screen (AIC-646)

### DIFF
--- a/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsViewModel.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/AudioDetailsViewModel.kt
@@ -164,7 +164,14 @@ class AudioDetailsViewModel @Inject constructor(
                 }.bindTo(transcript)
                 .disposedBy(disposeBag)
 
-
+        /**
+         * No need to display transcript and credits while playing {ArticTour}.
+         */
+        objectObservable.filterTo<Playable, ArticTour>()
+                .subscribeBy {
+                    transcript.onNext("")
+                    credits.onNext("")
+                }.disposedBy(disposeBag)
     }
 
     /**

--- a/media_ui/src/main/res/layout/fragment_audio_details.xml
+++ b/media_ui/src/main/res/layout/fragment_audio_details.xml
@@ -172,7 +172,6 @@
                 app:panel_padding="@dimen/marginDouble"
                 app:content_padding="@dimen/marginDouble"
                 app:title_text="@string/transcript"
-                android:visibility="gone"
                 app:title_text_color="@color/white" />
 
             <View
@@ -188,7 +187,6 @@
                 app:panel_padding="@dimen/marginDouble"
                 app:content_padding="@dimen/marginDouble"
                 app:title_text="@string/credits"
-                android:visibility="gone"
                 app:title_text_color="@color/white" />
 
             <TextView


### PR DESCRIPTION
This changes the logic slightly: the `transcript` and `credit` ViewGroups are now visible by default. This means, of course, that we need to hide them if the current `Playable` is a Tour....