### PR TITLE
Fix crash that happens while details screen is resumed from background 

### DIFF
--- a/details/src/main/kotlin/edu/artic/details/DetailsActivity.kt
+++ b/details/src/main/kotlin/edu/artic/details/DetailsActivity.kt
@@ -11,17 +11,19 @@ class DetailsActivity: BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (navController.currentDestination?.id == navController.graph.startDestination) {
+            when {
+                intent.hasExtra(EventDetailFragment.ARG_EVENT) -> {
+                    navController.navigate(R.id.goToEventDetails)
+                }
+                intent.hasExtra(TourDetailsFragment.ARG_TOUR) -> {
+                    navController.navigate(R.id.goToTourDetails)
+                }
+                else -> {
+                    navController.navigate(R.id.goToExhibitionDetails)
+                }
+            }
 
-        when {
-            intent.hasExtra(EventDetailFragment.ARG_EVENT) -> {
-                navController.navigate(R.id.goToEventDetails)
-            }
-            intent.hasExtra(TourDetailsFragment.ARG_TOUR) -> {
-                navController.navigate(R.id.goToTourDetails)
-            }
-            else -> {
-                navController.navigate(R.id.goToExhibitionDetails)
-            }
         }
     }
 }


### PR DESCRIPTION
We only want to navigate to a specific `details` fragment if the current screen is empty.

`NavController` tries to help us by restoring its navigation state in `::onCreate`. We weren't prepared for that, so if `DetailsActivity` were recreated the app would just crash.