### PR TITLE
Update to latest Mockito-Kotlin (2.1.0) to fix test execution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     // Test-only dependencies below this point
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     // Our tests use the standard Java variant of the 310 backport..
     testImplementation('org.threeten:threetenbp:1.3.7') {
         // ...so we need to explicitly exclude the Android variant here

--- a/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
+++ b/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
@@ -1,9 +1,9 @@
 package edu.artic.db
 
 import android.arch.persistence.db.SupportSQLiteOpenHelper
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import edu.artic.db.daos.*
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver

--- a/app/src/test/kotlin/edu/artic/splash/ErrorMessagePresenterTest.kt
+++ b/app/src/test/kotlin/edu/artic/splash/ErrorMessagePresenterTest.kt
@@ -1,9 +1,9 @@
 package edu.artic.splash
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
 import edu.artic.base.NetworkException
 import edu.artic.db.AppDataPreferencesManager
 import org.junit.Assert


### PR DESCRIPTION
My best guess is that the reflection logic in `mockito-kotlin:1.5.0` was not forward-compatible with `Kotlin 1.3.31`.