### PR TITLE
Permit system control of audio (AIC-651)

### DIFF
--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -204,7 +204,7 @@ class AudioPlayerService : DaggerService(), PlayerService {
      *
      * @see AudioManager.MODE_IN_COMMUNICATION
      */
-    internal var forceHeadsetMode: Boolean = true
+    internal var forceHeadsetMode: Boolean = false
 
 
     override fun onCreate() {

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -70,15 +70,16 @@ import javax.inject.Inject
 class AudioPlayerService : DaggerService(), PlayerService {
 
     companion object {
-        val FOREGROUND_CHANNEL_ID = "foreground_channel_id"
-        val NOTIFICATION_ID = 200
+        const val FOREGROUND_CHANNEL_ID = "foreground_channel_id"
+        const val NOTIFICATION_ID = 200
+
+        const val CANCEL_ACTION = "Cancel_Notification"
 
         fun getLaunchIntent(context: Context): Intent {
             return Intent(context, AudioPlayerService::class.java)
         }
     }
 
-    val CANCEL_ACTION = "Cancel_Notification"
     val EMPTY_AUDIO_FILE = AudioFileModel("",null,null,null,null,null, null, null, null)
 
     /**
@@ -340,10 +341,13 @@ class AudioPlayerService : DaggerService(), PlayerService {
 
                     override fun createCustomActions(context: Context, instanceId: Int): MutableMap<String, NotificationCompat.Action> {
                         val playIntent = Intent(CANCEL_ACTION).setPackage(context.packageName)
-                        return mutableMapOf(CANCEL_ACTION to NotificationCompat.Action(
-                                R.drawable.ic_close_circle,
-                                "Close",
-                                PendingIntent.getBroadcast(context, 0, playIntent, PendingIntent.FLAG_CANCEL_CURRENT)))
+                        return mutableMapOf(
+                                CANCEL_ACTION to NotificationCompat.Action(
+                                        R.drawable.ic_close_circle,
+                                        "Close",
+                                        PendingIntent.getBroadcast(context, 0, playIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+                                )
+                        )
                     }
 
                     override fun onCustomAction(player: Player?, action: String?, intent: Intent?) {

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -191,6 +191,20 @@ class AudioPlayerService : DaggerService(), PlayerService {
     lateinit var disposeBag: DisposeBag
     internal var currentBitmap: Bitmap? = null
 
+    /**
+     * Set this to true to tell the system we are currently in a call-like environment.
+     *
+     * On Android Pie devices, that would let the system load a reasonable
+     * volume-settings preset. Only takes effect when a [Playing] event passes
+     * through [audioPlayBackStatus].
+     *
+     * Assumption: [AudioManager.setMode] only affects the mode for this service. When
+     * we die, the mode will revert to its previous setting.
+     *
+     * @see AudioManager.MODE_IN_COMMUNICATION
+     */
+    internal var forceHeadsetMode: Boolean = true
+
 
     override fun onCreate() {
         super.onCreate()
@@ -234,9 +248,9 @@ class AudioPlayerService : DaggerService(), PlayerService {
             .subscribe {
                 when(it) {
                     is Playing -> {
-                        //Tell the system we are currently in a call like environment which
-                        //lets the system contextually update the volume on android pie
-                        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+                        if (forceHeadsetMode) {
+                            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+                        }
                         audioManager.isSpeakerphoneOn = false
                     }
                     else -> audioManager.mode = AudioManager.MODE_NORMAL


### PR DESCRIPTION
Before, we restricted playback to the earpiece at exclusion of all other connections (c.f. `AIC-271`, `AIC-272`, #218 ). It turned out that didn't work so well when headphones were plugged in, so we're disabling the behavior.