### PR TITLE
Avoid parsing null language tags (AIC-652)

### DIFF
--- a/localization/src/main/kotlin/edu/artic/localization/SpecifiesLanguage.kt
+++ b/localization/src/main/kotlin/edu/artic/localization/SpecifiesLanguage.kt
@@ -18,7 +18,17 @@ interface SpecifiesLanguage {
     fun underlyingLanguage() : String?
 
     fun underlyingLocale(): Locale {
-        return Locale.forLanguageTag(underlyingLanguage())
+        return underlyingLanguage()?.asLanguageTag().orFallback(Locale.ROOT)
+    }
+
+    /**
+     * Alias to [Locale.forLanguageTag].
+     *
+     * The SDK function's javadoc says that it'll throw a NullPointerException
+     * if its parameter is null, so we disallow null receivers here.
+     */
+    private fun String.asLanguageTag(): Locale {
+        return Locale.forLanguageTag(this)
     }
 
     /**

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -182,12 +182,22 @@ class AudioPlayerService : DaggerService(), PlayerService {
     val audioPlayBackStatus: Subject<PlayBackState> = BehaviorSubject.create()
     val currentTrack: Subject<AudioFileModel> = BehaviorSubject.create()
 
-    val disposeBag = DisposeBag()
+    /**
+     * Lifetime: [onCreate] to [onDestroy].
+     *
+     * Do not use after [onDestroy] or before [onCreate] (it's easy to accidentally do that
+     * if the service is being recreated).
+     */
+    lateinit var disposeBag: DisposeBag
     internal var currentBitmap: Bitmap? = null
 
 
     override fun onCreate() {
         super.onCreate()
+
+        // Make sure to clear this out in ::onDestroy.
+        disposeBag = DisposeBag()
+
         setUpNotificationManager()
         player.addListener(object : Player.DefaultEventListener() {
 
@@ -437,6 +447,8 @@ class AudioPlayerService : DaggerService(), PlayerService {
         super.onDestroy()
         playerNotificationManager.setPlayer(null)
         player.release()
+
+        // Make sure to replace 'disposeBag' with a new instance in ::onCreate.
         disposeBag.dispose()
     }
 


### PR DESCRIPTION
The implementation of `SpecifiesLanguage::underlyingLocale()` will throw a NullPointerException if the `SpecifiesLanguage` object in question doesn't have a language. This PR simply returns the `Locale.ROOT`constant from that method in such a scenario, but realistically we shouldn't even allow the creation of objects without a defined language.

I've been working on a more holistic solution to this problem in a separate branch - `pc-better-active-audio-file-guarantees` - but I haven't scoped out the implications of showing a language selector on the tour intro page yet. Regardless, this PR should be fully capable of working around the crashes.

@caguilar187 I'd like you to review. I think we need to discuss whether there might be an alternative to the current use of `EMPTY_AUDIO_FILE` in `AudioPlayerService.kt`, as I believe that is the specific cause of the crash described in AIC-652.