### PR TITLE
Feature: Update compile & target SDKs and various dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,13 +41,7 @@ captures/
 
 # IntelliJ
 *.iml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/dictionaries
-.idea/libraries
-.idea/caches
+.idea/
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.

--- a/access_card/build.gradle
+++ b/access_card/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/adapter/src/main/java/edu/artic/adapter/AutoHolderRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/AutoHolderRecyclerViewAdapter.kt
@@ -19,7 +19,7 @@ import java.lang.reflect.ParameterizedType
  * * In [onBindView], implement binding logic in reference to `this` (where
  *    `this` is the inflated version of that same layout).
  */
-abstract class AutoHolderRecyclerViewAdapter<VB : ViewBinding, TModel> :
+abstract class AutoHolderRecyclerViewAdapter<VB : ViewBinding, TModel : Any> :
     BaseRecyclerViewAdapter<TModel, BaseViewHolder> {
 
     constructor(diffItemCallback: DiffUtil.ItemCallback<TModel>) : super(diffItemCallback)

--- a/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseAdapterBinder.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 /**
  * Description: Convenience conversion method that turns this object into a [BaseAdapter].
  */
-fun <TModel> BaseRecyclerViewAdapter<TModel, *>.toBaseAdapter(): BaseAdapter =
+fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.toBaseAdapter(): BaseAdapter =
     BaseAdapterBinder(this)
 
 /**
@@ -20,7 +20,7 @@ fun <TModel> BaseRecyclerViewAdapter<TModel, *>.toBaseAdapter(): BaseAdapter =
  * Must be a function due to Kotlin's type inference.
  */
 @Suppress("UNCHECKED_CAST")
-fun <TModel> SpinnerAdapter.baseRecyclerViewAdapter(): BaseRecyclerViewAdapter<TModel, BaseViewHolder> =
+fun <TModel : Any> SpinnerAdapter.baseRecyclerViewAdapter(): BaseRecyclerViewAdapter<TModel, BaseViewHolder> =
     (this as BaseAdapterBinder<TModel>).adapter as BaseRecyclerViewAdapter<TModel, BaseViewHolder>
 
 /**
@@ -43,7 +43,7 @@ interface DropDownAdapter<TModel, VH : BaseViewHolder> {
      * Called when the [BaseViewHolder] is first created in the scope of it's itemView. Perform
      * initial registering of view bindings here that respond outside normal onClickListener.
      */
-    @Suppress("UNUSED_PARAMETER", "unused")
+    @Suppress("unused")
     fun View.onDropdownHolderCreated(parent: ViewGroup, viewType: Int) = Unit
 }
 
@@ -53,7 +53,7 @@ interface DropDownAdapter<TModel, VH : BaseViewHolder> {
  * without needing to use a different implementation.
  * @author Andrew Grosner (Fuzz)
  */
-class BaseAdapterBinder<TModel>(
+class BaseAdapterBinder<TModel : Any>(
     val adapter: BaseRecyclerViewAdapter<TModel, *>,
 ) : BaseAdapter() {
 

--- a/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
+++ b/adapter/src/main/java/edu/artic/adapter/BaseRecyclerViewAdapter.kt
@@ -24,7 +24,7 @@ import java.util.*
  * `Model-View-ViewModel`) architectures. Main selling points are as
  * follows:
  */
-abstract class BaseRecyclerViewAdapter<TModel, VH : BaseViewHolder>(
+abstract class BaseRecyclerViewAdapter<TModel : Any, VH : BaseViewHolder>(
     private val diffItemCallback: DiffUtil.ItemCallback<TModel> = object :
         DiffUtil.ItemCallback<TModel>() {
         override fun areItemsTheSame(oldItem: TModel, newItem: TModel): Boolean =

--- a/adapter/src/main/java/edu/artic/adapter/ViewPagerAdapterBinder.kt
+++ b/adapter/src/main/java/edu/artic/adapter/ViewPagerAdapterBinder.kt
@@ -9,12 +9,12 @@ import android.view.ViewGroup
  * @author Sameer Dhakal (Fuzz)
  */
 
-fun <TModel> BaseRecyclerViewAdapter<TModel, *>.toPagerAdapter() = ViewPagerAdapterBinder(this)
+fun <TModel : Any> BaseRecyclerViewAdapter<TModel, *>.toPagerAdapter() = ViewPagerAdapterBinder(this)
 
 /**
  * Description: Binds a [BaseRecyclerViewAdapter] to a [PagerAdapter]
  */
-open class ViewPagerAdapterBinder<TModel>(
+open class ViewPagerAdapterBinder<TModel : Any>(
         val adapter: BaseRecyclerViewAdapter<TModel, *>) : androidx.viewpager.widget.PagerAdapter() {
 
     init {

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 
@@ -37,8 +37,8 @@ dependencies {
     implementation project(":location")
     implementation project(":membership")
 
-    implementation platform('com.google.firebase:firebase-bom:31.2.1')
-    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation platform('com.google.firebase:firebase-bom:33.4.0')
+    implementation 'com.google.firebase:firebase-analytics'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,17 +6,17 @@ plugins {
     id 'com.google.firebase.crashlytics'
 }
 
-String majorAndMinorVersion = "1.6"
-Integer patchVersionCode = 4
+String majorAndMinorVersion = "1.7"
+Integer patchVersionCode = 0
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
     defaultConfig {
         applicationId "edu.artic"
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
         multiDexEnabled true
-        versionCode(patchVersionCode + 1500)
+        versionCode(patchVersionCode + 1600)
         versionName "$majorAndMinorVersion.$patchVersionCode"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
@@ -118,14 +118,14 @@ dependencies {
     implementation libs.threeten
     implementation libs.progress_interceptor
 
-    implementation platform('com.google.firebase:firebase-bom:31.2.1')
-    implementation 'com.google.firebase:firebase-analytics-ktx'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation platform('com.google.firebase:firebase-bom:33.4.0')
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.github.anrwatchdog:anrwatchdog:1.4.0'
 
     //The following four lines enable our usage of dagger2 dependency injection
     implementation libs.dagger
-    implementation 'androidx.lifecycle:lifecycle-process:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-process:2.9.1'
     kapt libs.dagger_compiler
     implementation libs.dagger_android
     kapt libs.dagger_android_compiler

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ android {
                     buildConfigField "String", "VERSION_NAME_FOR_DISPLAY", "\"$majorAndMinorVersion.$patchVersionCode+$buildMetadata\""
                 }
             }
+            manifestPlaceholders = [crashlyticsCollectionEnabled:"false"]
         }
         release {
             buildConfigField "String", "FB_APPLICATION_ID", "\"${envVariable("fb_application_id", true)}\""
@@ -82,6 +83,7 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+            manifestPlaceholders = [crashlyticsCollectionEnabled:"true"]
         }
     }
     namespace 'edu.artic'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,11 +18,6 @@
             android:value="@integer/google_play_services_version" />
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
-            android:value="false" />
-
-        <provider
-            android:name="com.google.firebase.provider.FirebaseInitProvider"
-            android:authorities="${applicationId}.firebaseinitprovider"
-            tools:node="remove" />
+            android:value="true" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,6 @@
             android:value="@integer/google_play_services_version" />
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
-            android:value="true" />
+            android:value="${crashlyticsCollectionEnabled}" />
     </application>
 </manifest>

--- a/app/src/main/kotlin/edu/artic/ArticApp.kt
+++ b/app/src/main/kotlin/edu/artic/ArticApp.kt
@@ -29,24 +29,12 @@ class ArticApp : DaggerApplication(), LifecycleObserver {
         }
 
         AndroidThreeTen.init(this)
-        FirebaseApp.initializeApp(this, firebaseOptions())
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 
     override fun applicationInjector() = seedBuilder(DaggerAppComponent.builder())
 
-    fun firebaseOptions(): FirebaseOptions {
-        return FirebaseOptions.Builder()
-            .setApiKey(BuildConfig.FB_API_KEY)
-            .setApplicationId(BuildConfig.FB_APPLICATION_ID)
-            .setGaTrackingId(BuildConfig.GA_TRACKING_ID)
-            .setGcmSenderId(BuildConfig.GCM_SENDER_ID)
-            .setProjectId(BuildConfig.FB_PROJECT_ID)
-            .setStorageBucket(BuildConfig.FB_STORAGE_BUCKET)
-            .build()
-    }
-
-    fun seedBuilder(builder: AppComponent.Builder): AppComponent {
+    private fun seedBuilder(builder: AppComponent.Builder): AppComponent {
         builder.seedInstance(this)
         val component = builder.build()
         ArticComponent.setInternalAppComponent(component)

--- a/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
+++ b/app/src/main/kotlin/edu/artic/CrashlyticsTree.kt
@@ -1,6 +1,7 @@
 package edu.artic
 
 import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import timber.log.Timber
 
 
@@ -10,19 +11,15 @@ import timber.log.Timber
  */
 
 class CrashlyticsTree : Timber.Tree() {
-
-    private val reportableLogs: Set<Int> = setOf(Log.ERROR)
+    override fun isLoggable(tag: String?, priority: Int): Boolean {
+        return priority >= Log.WARN
+    }
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        FirebaseCrashlytics.getInstance().log("$tag: $message")
 
-        if (reportableLogs.contains(priority)) {
-            return
+        if (t != null) {
+            FirebaseCrashlytics.getInstance().recordException(t)
         }
-
-//        Crashlytics.log(message)
-//
-//        if (t != null) {
-//            Crashlytics.logException(t)
-//        }
     }
 }

--- a/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
+++ b/app/src/test/kotlin/edu/artic/db/AppDataManagerTest.kt
@@ -42,23 +42,27 @@ class AppDataManagerTest {
         doReturn(openHelper).`when`(database).openHelper
 
         appDataProvider = mock()
-        appDataManager = AppDataManager(serviceProvider = appDataProvider,
-                appDataPreferencesManager = appDataPrefManager,
-                dashboardDao = dashboardDao,
-                generalInfoDao = generalInfoDao,
-                galleryDao = galleryDao,
-                objectDao = objectDao,
-                audioFileDao = audioFileDao,
-                appDatabase = database,
-                dataObjectDao = mock(),
-                eventDao = mock(),
-                exhibitionCMSDao = mock(),
-                exhibitionDao = mock(),
-                mapAnnotationDao = mock(),
-                tourDao = mock(),
-                searchSuggestionDao = mock(),
-                articMapFloorDao = mock(),
-                appDataPrefManager = mock()
+        appDataManager = AppDataManager(
+            serviceProvider = appDataProvider,
+            appDataPreferencesManager = appDataPrefManager,
+            dashboardDao = dashboardDao,
+            generalInfoDao = generalInfoDao,
+            galleryDao = galleryDao,
+            objectDao = objectDao,
+            audioFileDao = audioFileDao,
+            appDatabase = database,
+            dataObjectDao = mock(),
+            eventDao = mock(),
+            exhibitionCMSDao = mock(),
+            exhibitionDao = mock(),
+            mapAnnotationDao = mock(),
+            tourDao = mock(),
+            searchSuggestionDao = mock(),
+            articMapFloorDao = mock(),
+            appDataPrefManager = mock(),
+            messageDao = mock(),
+            memberDataProvider = mock(),
+            memberInfoPreferencesManager = mock()
         )
     }
 
@@ -71,21 +75,22 @@ class AppDataManagerTest {
 
         val mockedAppData: ProgressDataState = mock()
 
-        doReturn(Observable.just(HashMap<String, List<String>>())).`when`(appDataProvider).getBlobHeaders()
+        doReturn(Observable.just(HashMap<String, List<String>>())).`when`(appDataProvider)
+            .getBlobHeaders()
         doReturn(Observable.just(mockedAppData)).`when`(appDataProvider).getBlob()
 
         val subscriptionInterceptor = LinkedBlockingQueue<Runnable>()
         val testObserver = TestObserver<ProgressDataState>()
 
         appDataManager.getBlob()
-                .observeOn(Schedulers.from { r -> subscriptionInterceptor.add(r) })
-                .subscribe(testObserver)
+            .observeOn(Schedulers.from { r -> subscriptionInterceptor.add(r) })
+            .subscribe(testObserver)
 
         subscriptionInterceptor
-                // This blocks until we observe the first emission from the ::getBlob call...
-                .take()
-                // ..at which point we can synchronously execute ::subscribeActual
-                .run()
+            // This blocks until we observe the first emission from the ::getBlob call...
+            .take()
+            // ..at which point we can synchronously execute ::subscribeActual
+            .run()
 
         verify(appDataProvider, Times(1)).getBlobHeaders()
         verify(appDataProvider, Times(1)).getBlob()

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/base/src/main/java/edu/artic/base/utils/customTab/CustomTabManager.kt
+++ b/base/src/main/java/edu/artic/base/utils/customTab/CustomTabManager.kt
@@ -38,14 +38,15 @@ class CustomTabManager : LifecycleAwareActivity {
 
 
     override fun onStart(host: Activity) {
-
         try {
             // We want to support alternative CustomTabs packages, like chrome dev
             // and firefox, so we're not hardcoding a package name here.
             val packageName = CustomTabsHelper.getPackageNameToUse(host)
             canBind = !TextUtils.isEmpty(packageName)
             if (canBind) {
-                CustomTabsClient.bindCustomTabsService(host, packageName, mCustomTabsServiceConnection)
+                mCustomTabsServiceConnection?.let {
+                    CustomTabsClient.bindCustomTabsService(host, packageName, it)
+                }
             }
         } catch (t: Throwable) {
             // Package lookup failed. Nothing to be done.

--- a/base/src/main/res/values-v35/styles.xml
+++ b/base/src/main/res/values-v35/styles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="toolbarStyle">@style/Widget.AppCompat.Toolbar.Ideal</item>
+        <item name="buttonStyle">@style/Widget.AppCompat.Button.Tinted</item>
+        <item name="android:fontFamily">@font/ideal_sans_book</item>
+        <item name="android:fontFeatureSettings">tnum</item>
+        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,18 @@
 
 buildscript {
     ext {
-        compileSdk = 34
+        compileSdk = 35
         minSdk = 21
-        kotlin_version = '1.8.0'
+        kotlin_version = '1.9.25'
         latest_helper = '72626c5db8'
         dagger_version = '2.19'
-        support_version = '28.0.0'
         arch_version = '1.1.1'
-        navigation_version = '1.0.0-alpha05'
         paging_version = '1.0.1'
         rx_binding_version = '2.1.1'
-        kotshi_version = '1.0.4'
-        moshi_version = '1.14.0'
-        room_version = '1.1.1'
-        glide_version = '4.12.0'
-        firebase_version = '16.0.4'
-        crashlytics_version = '2.9.5'
-        exo_player_version = '2.16.0'
+        moshi_version = '1.15.2'
+        room_version = '2.6.1'
+        glide_version = '4.16.0'
+        exo_player_version = '2.19.1'
 
         libs = [
                 kotlin                  : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version",
@@ -42,46 +37,45 @@ buildscript {
                 retrofit_scalars        : 'com.squareup.retrofit2:converter-scalars:2.1.0',
                 retrofit_moshi          : 'com.squareup.retrofit2:converter-moshi:2.1.0',
                 retrofit_xml_converter  : "com.squareup.retrofit2:converter-simplexml:2.3.0",
-                maps_utils              : "com.google.maps.android:android-maps-utils:0.5",
+                maps_utils              : "com.google.maps.android:android-maps-utils:3.8.2",
                 moshi                   : "com.squareup.moshi:moshi:${moshi_version}",
                 moshi_kotlin_compiler   : "com.squareup.moshi:moshi-kotlin-codegen:${moshi_version}",
                 moshi_kotlin            : "com.squareup.moshi:moshi-kotlin:${moshi_version}",
-                room                    : 'androidx.room:room-runtime:2.4.3',
-                room_compiler           : 'androidx.room:room-compiler:2.4.3',
-                room_rx                 : 'androidx.room:room-rxjava2:2.4.3',
-                timber                  : 'com.jakewharton.timber:timber:4.5.1',
+                room                    : "androidx.room:room-runtime:${room_version}",
+                room_compiler           : "androidx.room:room-compiler:${room_version}",
+                room_rx                 : "androidx.room:room-rxjava2:${room_version}",
+                timber                  : 'com.jakewharton.timber:timber:5.0.1',
                 threeten                : 'com.jakewharton.threetenabp:threetenabp:1.1.1',
                 v4_support              : 'androidx.legacy:legacy-support-v4:1.0.0',
                 design_support          : 'com.google.android.material:material:1.0.0',
-                constraint_layout       : 'androidx.constraintlayout:constraintlayout:2.1.4',
+                constraint_layout       : 'androidx.constraintlayout:constraintlayout:2.2.1',
                 glide                   : "com.github.bumptech.glide:glide:${glide_version}",
                 glide_compiler          : "com.github.bumptech.glide:compiler:${glide_version}",
                 glide_okhttp_integration: "com.github.bumptech.glide:okhttp3-integration:${glide_version}@aar",
                 progress_interceptor    : 'com.github.cliabhach:okhttp3-downloadprogress-interceptor:1.0.2-a1',
-                maps                    : "com.google.android.gms:play-services-maps:18.2.0",
-                location                : "com.google.android.gms:play-services-location:21.0.1",
+                maps                    : "com.google.android.gms:play-services-maps:19.2.0",
+                location                : "com.google.android.gms:play-services-location:21.3.0",
                 exo_player_core         : "com.google.android.exoplayer:exoplayer-core:$exo_player_version",
                 exo_player_dash         : "com.google.android.exoplayer:exoplayer-dash:$exo_player_version",
                 exo_player_ui           : "com.google.android.exoplayer:exoplayer-ui:$exo_player_version",
                 exo_player_media_session: "com.google.android.exoplayer:extension-mediasession:$exo_player_version",
                 media_compat            : 'androidx.media:media:1.0.0',
                 view_indicator          : "com.github.fuzz-productions:CutoutViewIndicator:v0.8.2",
-                custom_tabs             : 'androidx.browser:browser:1.0.0',
-                zxing_core              : 'com.google.zxing:core:3.3.0'
+                custom_tabs             : 'androidx.browser:browser:1.8.0',
+                zxing_core              : 'com.google.zxing:core:3.5.3'
 
         ]
     }
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.11.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
-        classpath 'com.google.gms:google-services:4.3.15'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.0"
+        classpath 'com.google.gms:google-services:4.4.3'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -97,9 +91,8 @@ subprojects {
 
     repositories {
         google()
-        jcenter()
-        maven { url "https://www.jitpack.io" }
         mavenCentral()
+        maven { url "https://www.jitpack.io" }
     }
 
     if (name == 'app') {
@@ -154,8 +147,8 @@ subprojects {
         }
 
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
+            sourceCompatibility JavaVersion.VERSION_17
+            targetCompatibility JavaVersion.VERSION_17
         }
         sourceSets {
             main.java.srcDirs += 'src/main/kotlin'

--- a/content_listing/build.gradle
+++ b/content_listing/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -23,11 +23,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/details/build.gradle
+++ b/details/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/details/src/main/res/values-v35/styles.xml
+++ b/details/src/main/res/values-v35/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="DetailsTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/audioBackground</item>
+        <item name="colorPrimaryDark">@color/audioBackground</item>
+        <item name="android:colorPrimaryDark">@color/audioBackground</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,10 @@
 #
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 #

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip

--- a/image/build.gradle
+++ b/image/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/image/src/main/java/edu/artic/image/GlideRequestBuilderExtensions.kt
+++ b/image/src/main/java/edu/artic/image/GlideRequestBuilderExtensions.kt
@@ -39,7 +39,7 @@ inline fun RequestBuilder<Drawable>.listenerClean(
         crossinline onResourceReady: (resource: Drawable) -> Boolean)
         : RequestBuilder<Drawable> {
     return this.listener(object : RequestListener<Drawable> {
-        override fun onLoadFailed(e: GlideException?, model: Any, target: Target<Drawable>, isFirstResource: Boolean): Boolean {
+        override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>, isFirstResource: Boolean): Boolean {
             return onFailed.invoke()
         }
 

--- a/image/src/main/java/edu/artic/image/RXGlideExtensions.kt
+++ b/image/src/main/java/edu/artic/image/RXGlideExtensions.kt
@@ -18,7 +18,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
  * @param width Specify a width to optimize image loading.
  * @param height Specify a height to optimize image loading.
  */
-inline fun <reified T> RequestBuilder<T>.asRequestObservable(context: Context,
+inline fun <reified T : Any> RequestBuilder<T>.asRequestObservable(context: Context,
                                                              width: Int = Target.SIZE_ORIGINAL,
                                                              height: Int = Target.SIZE_ORIGINAL): Observable<T> {
     return Observable.create { emitter ->

--- a/info/build.gradle
+++ b/info/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/localization/build.gradle
+++ b/localization/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/localization_ui/build.gradle
+++ b/localization_ui/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/location_ui/build.gradle
+++ b/location_ui/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/map/build.gradle
+++ b/map/build.gradle
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -24,11 +24,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/media/src/main/AndroidManifest.xml
+++ b/media/src/main/AndroidManifest.xml
@@ -1,10 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
 
     <application>
         <service
             android:name=".audio.AudioPlayerService"
+            android:foregroundServiceType="mediaPlayback"
             android:enabled="true"
             android:exported="false" />
     </application>

--- a/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
+++ b/media/src/main/java/edu/artic/media/audio/AudioPlayerService.kt
@@ -327,21 +327,12 @@ class AudioPlayerService : DaggerService(), PlayerService {
             override fun createCurrentContentIntent(player: Player): PendingIntent? {
                 //TODO make it dynamic so that activity that started the audio stream will be the destination of Intent
                 val notificationIntent = "edu.artic.audio".asDeepLinkIntent()
-                return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    PendingIntent.getActivity(
-                        this@AudioPlayerService,
-                        0,
-                        notificationIntent,
-                        PendingIntent.FLAG_MUTABLE
-                    )
-                } else {
-                    PendingIntent.getActivity(
-                        this@AudioPlayerService,
-                        0,
-                        notificationIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT
-                    )
-                }
+                return PendingIntent.getActivity(
+                    this@AudioPlayerService,
+                    0,
+                    notificationIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
             }
 
             override fun getCurrentContentText(player: Player): CharSequence? {

--- a/media_ui/build.gradle
+++ b/media_ui/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
@@ -81,9 +81,10 @@ class NarrowAudioPlayerFragment :
 
     override fun onResume() {
         super.onResume()
-        audioIntent = AudioPlayerService.getLaunchIntent(requireContext())
-        requireActivity().startService(audioIntent)
-        requireActivity().bindService(audioIntent, serviceConnection, 0)
+        val newAudioIntent = AudioPlayerService.getLaunchIntent(requireContext())
+        audioIntent = newAudioIntent
+        requireActivity().startService(newAudioIntent)
+        requireActivity().bindService(newAudioIntent, serviceConnection, 0)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/membership/build.gradle
+++ b/membership/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/message/build.gradle
+++ b/message/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/reactivex/build.gradle
+++ b/reactivex/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/splash/build.gradle
+++ b/splash/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/tour_manager/build.gradle
+++ b/tour_manager/build.gradle
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -24,11 +24,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -23,12 +23,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
 }

--- a/viewmodel/build.gradle
+++ b/viewmodel/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/welcome/build.gradle
+++ b/welcome/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 


### PR DESCRIPTION
This PR updates our project's various JDK and SDK versions so that we can start publishing app updates again:

- We increase our JDK version from 8 to 17 because it's required for more recent versions of the Android Gradle Plugin, which is required to use more recent SDKs.
- We increase our `compileSdkVersion` to 36, the newest available, in order to take advantage of the latest compile-time improvements. The Android team at Google generally recommends adopting new compileSdkVersions as soon as they're stable.
- We increase our `targetSdkVersion` to 35 instead of the newly released 36 because changing the target means opting into new user-facing behavior changes, which requires thorough review and testing. There are several significant changes that will have to be made before we can target 36, but that shouldn't be required by the Play Store until late 2026.

We're also updating our Kotlin compiler version and a whole slew of assorted dependencies and making required code changes to keep the project building. Note that out of pragmatism, we're not making the leap to Kotlin 2.x yet, which merits more thorough review. This also means we're not quite up-to-date on a few dependencies that require K2.x+; we can update those at a later date.

Last but not least, we're re-enabling Firebase Analytics and Crashlytics. Note that the project was previously set up to manually initialize Firebase using IDs and keys from the build environment. This made some sense given the original developers' infrastructure, but for simplicity's sake we're just going to use the recommended method of letting Firebase initialize itself from the `google-services.json` config.