### PR TITLE
Fix: Handle null arguments in Language Settings fragment

### DIFF
--- a/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
+++ b/localization_ui/src/main/java/edu/artic/localization/ui/LanguageSettingsFragment.kt
@@ -40,7 +40,7 @@ class LanguageSettingsFragment :
      * No need to recreate the activity in splash mode ([LanguageSettingsFragment] is dismissed
      * upon language selection).
      */
-    private val splashMode by lazy { arguments!!.getBoolean(ARG_LANGUAGE_SETTINGS) }
+    private val splashMode by lazy { arguments?.getBoolean(ARG_LANGUAGE_SETTINGS) ?: false }
 
     private val availableLocales =
         listOf(Locale.ENGLISH, SPANISH, Locale.CHINESE, Locale.KOREAN, Locale.FRENCH)


### PR DESCRIPTION
When this project was originally written, the version of the `Fragment` class that was used couldn't have a null `arguments` property; it would be an empty `Bundle` if no arguments were passed when the Fragment was created. The newer `Fragment` class's `arguments` is null if no arguments were passed, however, so now we need to check for null `arguments` and return false.

Before:

https://github.com/user-attachments/assets/e0c277ec-55ef-4085-bd85-1d2944455d72

After:


https://github.com/user-attachments/assets/0cc14855-2b6f-4527-bcc5-efb01aecc42f