### PR TITLE
Fix: Add localized strings for museum hours

### DIFF
--- a/info/src/main/java/edu/artic/info/MuseumInformationViewModel.kt
+++ b/info/src/main/java/edu/artic/info/MuseumInformationViewModel.kt
@@ -36,6 +36,8 @@ class MuseumInformationViewModel @Inject constructor(
                 .toObservable()
                 .map { languageSelector.selectFrom(it.allTranslations()) }
                 .map { it.museumHours }
+                // prevent an empty field in the CMS from overwriting the local copy
+                .filter { it.isNotBlank() }
                 .bindTo(museumHours)
                 .disposedBy(disposeBag)
 

--- a/info/src/main/res/layout/fragment_museum_information.xml
+++ b/info/src/main/res/layout/fragment_museum_information.xml
@@ -81,7 +81,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/dividerBelowMuseumInformation"
-                    tools:text="Open daily 10:30am to 5:00pm Thursday until 8:00am" />
+                    android:text="@string/info_museum_hours_fallback" />
 
                 <TextView
                     android:id="@+id/museumAddress"

--- a/info/src/main/res/values-en/strings.xml
+++ b/info/src/main/res/values-en/strings.xml
@@ -23,4 +23,5 @@
 	<!-- This is only used on iOS -->
 	<string name="info_designed_by">Designed by Potion</string>
 	<string name="info_member_log_in_header">Already a Member?</string>
+	<string name="info_museum_hours_fallback">Learn about our hours and visiting policies at artic.edu/visit</string>
 </resources>

--- a/info/src/main/res/values-es/strings.xml
+++ b/info/src/main/res/values-es/strings.xml
@@ -23,4 +23,5 @@
 	<!-- This is only used on iOS -->
 	<string name="info_designed_by">Diseñado por Potion</string>
 	<string name="info_member_log_in_header">¿Ya es miembro?</string>
+    <string name="info_museum_hours_fallback">Aprenda más sobre nuestras horas de operación y políticas para visitantes en artic.edu/visit</string>
 </resources>

--- a/info/src/main/res/values-fr/strings.xml
+++ b/info/src/main/res/values-fr/strings.xml
@@ -23,4 +23,5 @@
 	<!-- This is only used on iOS -->
 	<string name="info_designed_by">Conçu par Potion</string>
 	<string name="info_member_log_in_header">Déjà membre ?</string>
+    <string name="info_museum_hours_fallback">Apprenez nos heures et politiques de visiteur à artic.edu/visit</string>
 </resources>

--- a/info/src/main/res/values-ko/strings.xml
+++ b/info/src/main/res/values-ko/strings.xml
@@ -23,4 +23,5 @@
 	<!-- This is only used on iOS -->
 	<string name="info_designed_by">디자인</string>
 	<string name="info_member_log_in_header">이미 회원이십니까?</string>
+    <string name="info_museum_hours_fallback">저희 운영 시간과 관람 정보에 대해 artic.edu/visit 에서 확인하세요</string>
 </resources>

--- a/info/src/main/res/values-zh/strings.xml
+++ b/info/src/main/res/values-zh/strings.xml
@@ -23,4 +23,5 @@
 	<!-- This is only used on iOS -->
 	<string name="info_designed_by">设计人员 Potion</string>
 	<string name="info_member_log_in_header">已经是会员？</string>
+    <string name="info_museum_hours_fallback">了解更多关于我们的营业时间和参观规定, 请访问 artic.edu/visit</string>
 </resources>

--- a/info/src/main/res/values/strings.xml
+++ b/info/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="info_museum_phone_number" translatable="false">+1 312 443 3600</string>
     <string name="info_dial_prompt">Select an app to dial that number</string>
     <string name="info_map_prompt">Select an app to view map</string>
-
+    <string name="info_museum_hours_fallback">Learn about our hours and visiting policies at artic.edu/visit</string>
 
     <!-- Since we heavily depend on the google maps api we are considering google map to handle the museum location search.-->
     <string name="info_museum_google_map_query" translatable="false"><![CDATA[https://www.google.com/maps/search/?api=1&query=The+Art+Institute+of+Chicago]]></string>


### PR DESCRIPTION
This PR adds localized strings for the museum hours field in the Museum Information screen for all languages. But since the CMS field is still populated for at least some languages, we'll continue to use that via the view binding if and only if it's not a blank string.

Before (e.g. Spanish):

<img src="https://github.com/user-attachments/assets/32a1de22-a782-41b2-a32c-e7279bd56ed9" width="300">

After:

<img src="https://github.com/user-attachments/assets/a22b9609-059c-4417-a4ec-440db13a1fed" width="300">
