### PR TITLE
Remove old Room database migration workaround 

### DIFF
--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -318,14 +318,6 @@ class AppDataManager @Inject constructor(
      */
     @WorkerThread
     private fun enforceSanityCheck() {
-        // Make sure we're not bitten by https://issuetracker.google.com/issues/111504749
-        // TODO: Remove this '::close' when we start using Room 2.1.0-a1 or higher
-        if (!appDatabase.isOpen) {
-            // This _should_ be a no-op, but in Room 2.0.0 and earlier it may release a stale database reference.
-            appDatabase.openHelper.close()
-            // If it did release a reference, the next line will throw with a helpful (though long) error message
-        }
-
         if (generalInfoDao.getRowCount() != 1 || dataObjectDao.getRowCount() != 1) {
             // Absolutely no reason to keep previous data. Destroy it.
             appDataPreferencesManager.lastModified = ""


### PR DESCRIPTION
One of the outdated dependencies that was updated [in this PR](https://github.com/art-institute-of-chicago/aic-mobile-android/pull/382/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R14) was Room, the database framework that our app uses to persist the CMS content to disk and populate the app. As it turns out, that update turned an old migration-enabling workaround into a migration-stopping bug! Fortunately, the fix was as simple as doing exactly what the comment said to do and removing the workaround. Thanks, past developer. 👍 