### PR TITLE
Feature: Update map zoom

### DIFF
--- a/map/build.gradle
+++ b/map/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     kapt libs.dagger_compiler
     kapt libs.dagger_android_compiler
 
-    implementation 'de.hdodenhof:circleimageview:2.2.0'
+    implementation 'de.hdodenhof:circleimageview:3.1.0'
 
     api libs.design_support
 

--- a/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapConstructs.kt
@@ -17,7 +17,7 @@ const val ZOOM_INITIAL: ZoomLevel = 17.4f
 const val ZOOM_DEPARTMENTS: ZoomLevel = 18.0f
 const val ZOOM_DEPARTMENT_AND_SPACES: ZoomLevel = 19.0f
 const val ZOOM_INDIVIDUAL: ZoomLevel = 20.3f
-const val ZOOM_MAX: ZoomLevel = 20.999999f
+const val ZOOM_MAX: ZoomLevel = 21.999999f
 const val ZOOM_MIN: ZoomLevel = 17.0f
 
 /**

--- a/map/src/main/kotlin/edu/artic/map/MarkerGenerators.kt
+++ b/map/src/main/kotlin/edu/artic/map/MarkerGenerators.kt
@@ -121,17 +121,16 @@ class ArticObjectMarkerGenerator(context: Context) : BaseMarkerGenerator(context
      * may crash.
      */
     fun makeIcon(imageViewBitmap: Bitmap?, scale: Float = 1f, overlay: String? = null, selected: Boolean = false): Bitmap {
+        if (imageViewBitmap != null) {
+            imageView.setImageBitmap(imageViewBitmap)
+        } else {
+            imageView.setImageDrawable(defaultImage)
+        }
 
         if (selected) {
             imageView.borderWidth = imageView.resources.dpToPixels(4f).toInt()
         } else {
             imageView.borderWidth = imageView.resources.dpToPixels(2f).toInt()
-        }
-
-        if (imageViewBitmap != null) {
-            imageView.setImageBitmap(imageViewBitmap)
-        } else {
-            imageView.setImageDrawable(defaultImage)
         }
 
         if (overlay != null) {

--- a/map/src/main/kotlin/edu/artic/map/rendering/BaseMapTileProvider.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/BaseMapTileProvider.kt
@@ -34,7 +34,7 @@ internal val evaluatedBoundsMap
             18 to Bounds(minX = 67263, minY = 97426, maxX = 67270, maxY = 97433),
             19 to Bounds(minX = 134527, minY = 194852, maxX = 134541, maxY = 194868),
             20 to Bounds(minX = 269055, minY = 389704, maxX = 269084, maxY = 389733),
-            21 to Bounds(minX = 538108, minY = 779412, maxX = 538167, maxY = 779471),
+            21 to Bounds(minX = 538111, minY = 779408, maxX = 538170, maxY = 77947100),
             22 to Bounds(minX = 1076217, minY = 1558824, maxX = 1076334, maxY = 1558942))
 
 abstract class BaseMapTileProvider : TileProvider {

--- a/map/src/main/kotlin/edu/artic/map/rendering/GlideMapTileProvider.kt
+++ b/map/src/main/kotlin/edu/artic/map/rendering/GlideMapTileProvider.kt
@@ -1,12 +1,12 @@
 package edu.artic.map.rendering
 
 import android.content.Context
+import android.util.Log
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.google.android.gms.maps.model.Tile
 import edu.artic.db.models.ArticMapFloor
 import edu.artic.image.GlideApp
 import timber.log.Timber
-import java.io.IOException
 import kotlin.math.pow
 
 /**
@@ -14,6 +14,9 @@ import kotlin.math.pow
  */
 class GlideMapTileProvider(private val context: Context,
                            private val floor: ArticMapFloor) : BaseMapTileProvider() {
+    companion object {
+        private const val TAG = "GlideMapTileProvider"
+    }
 
     val defaultTile = Tile(
             TILE_SIZE.toInt(),
@@ -48,8 +51,8 @@ class GlideMapTileProvider(private val context: Context,
                             TILE_SIZE.toInt(),
                             array
                     )
-                } catch (e: IOException) {
-                    Timber.e("Could not find tile with $path")
+                } catch (e: Exception) {
+                    Timber.tag(TAG).log(Log.ERROR, e, "Could not find tile with $path")
                     null
                 }
             }

--- a/map/src/main/res/values-v35/styles.xml
+++ b/map/src/main/res/values-v35/styles.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme.CustomToolbar.MapTheme">
+        <item name="colorAccent">@color/marine</item>
+        <item name="colorPrimary">@color/marine</item>
+        <item name="colorPrimaryDark">@color/marine</item>
+        <item name="android:colorAccent">@color/marine</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
This PR increases the maximum zoom of our map, allowing it to fetch the new zoom level 6 tiles. Note that Google Maps SDK technically allows a max zoom of 22 (even though Google won't let us use it today 🫠 ), while we set our max to just _under_ 22. This is because if we actually could reach 22 then the app would request zoom level 7 tiles, which aren't available. I also slightly adjusted the bounds of the tiles at zoom level 6 to better line them up with the real latitude and longitude values of the rooms and objects in the museum.

There are also two bug fixes for map-related crashes that are reported in the current production app:

1.  We use a third party library called [CircleImageView](https://github.com/hdodenhof/CircleImageView) to render our map markers. There was sometimes a crash inside that library when we tried to set the circle's border width but the image bitmap used in it had already been recycled. First, the version of the library we were using was years outdated and the code that crashed is no longer present in the latest version. But second, I've reordered the code in the `makeIcon` function so that a new bitmap is always set _before_ we make any other adjustments to the imageview.
2. In our TileProvider implementation, we were attempting to catch only `IOException`s when fetching new tiles from the server with Glide, our image fetching/caching library. If the exception is caught then we log it and return `null`, which is the expected value when a tile can't be fetched and signals Google Maps to try again with an exponential backoff. But the code inside the try block can't actually throw an `IOException`; instead it can throw `ExecutionException`s wrapping `GlideException`s or `InterruptedException`s, which are not caught and just crash the app. At any rate, the correct way to handle _any_ exception in the tile provider is to return null, so that's what we'll do.