### PR TITLE
Feature: Show boosted off view search results

### DIFF
--- a/base/src/main/res/values-en/strings.xml
+++ b/base/src/main/res/values-en/strings.xml
@@ -50,4 +50,5 @@
 	<string name="global_accept_action">OK</string>
 	<string name="messages_next_action">Next Message</string>
 	<string name="messages_previous_action">Previous Message</string>
+	<string name="search_currently_off_view">Currently Off View</string>
 </resources>

--- a/base/src/main/res/values-es/strings.xml
+++ b/base/src/main/res/values-es/strings.xml
@@ -50,4 +50,5 @@
 	<string name="global_accept_action">OK</string>
 	<string name="messages_next_action">Mensaje siguiente</string>
 	<string name="messages_previous_action">Mensaje anterior</string>
+	<string name="search_currently_off_view">Acutualmente no está exhibido</string>
 </resources>

--- a/base/src/main/res/values-fr/strings.xml
+++ b/base/src/main/res/values-fr/strings.xml
@@ -50,4 +50,5 @@
 	<string name="global_accept_action">OK</string>
 	<string name="messages_next_action">Message suivant</string>
 	<string name="messages_previous_action">Message précédent</string>
+	<string name="search_currently_off_view">Pas exposé actuellement</string>
 </resources>

--- a/base/src/main/res/values-ko/strings.xml
+++ b/base/src/main/res/values-ko/strings.xml
@@ -50,4 +50,5 @@
 	<string name="global_loading_error_time_out">네트워크 연결 시간 초과. 다시 시도해 보세요.</string>
 	<string name="messages_next_action">다음 메시지</string>
 	<string name="messages_previous_action">이전 메시지</string>
+	<string name="search_currently_off_view">현재 전시 중</string>
 </resources>

--- a/base/src/main/res/values-zh/strings.xml
+++ b/base/src/main/res/values-zh/strings.xml
@@ -50,4 +50,5 @@
 	<string name="global_loading_error_time_out">Network time out. Please try again.</string>
 	<string name="messages_next_action">下一條訊息</string>
 	<string name="messages_previous_action">上一條訊息</string>
+	<string name="search_currently_off_view">目前不展出</string>
 </resources>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="event_register_action">Register</string>
     <string name="event_rental_visit_website_prompt">Visit our website to register.</string>
     <string name="search_gallery_number">Gallery %s</string>
+    <string name="search_currently_off_view">Currently Off View</string>
 
     <!--use this string resource if empty string required-->
     <string name="global_empty_string" translatable="false" />

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -58,5 +58,6 @@
 
     <string name="messages_next_action">Next Message</string>
     <string name="messages_previous_action">Previous Message</string>
+    <string name="content_gallery_number">Gallery %s</string>
 
 </resources>

--- a/db/src/main/kotlin/edu/artic/db/ApiBodyGenerator.kt
+++ b/db/src/main/kotlin/edu/artic/db/ApiBodyGenerator.kt
@@ -75,13 +75,11 @@ sealed class ApiBodyGenerator {
                     "artist_display",
                     "image_id",
                     "gallery_id",
-                    "latlon"
+                    "latlon",
+                    "latitude",
+                    "longitude",
+                    "is_boosted"
             )
-            artworkParams["query"] = mutableMapOf<String, Any>().apply {
-                this["term"] = mutableMapOf<String, Any>().apply {
-                    this["is_on_view"] = "true"
-                }
-            }
             return artworkParams
         }
 

--- a/db/src/main/kotlin/edu/artic/db/models/ApiSearchResult.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ApiSearchResult.kt
@@ -61,8 +61,17 @@ sealed class ApiSearchContent {
             @Json(name = "artist_display") val artist_display: String,
             @Json(name = "image_id") val image_id: String?,
             @Json(name = "gallery_id") val gallery_id: String,
-            @Json(name = "latlon") val latlon: String?
-    ) : ApiSearchContent()
+            @Json(name = "latlon") val latlon: String?,
+            @Json(name = "latitude") val latitude: String?,
+            @Json(name = "longitude") val longitude: String?,
+            @Json(name = "is_boosted") val isBoosted: Boolean?,
+    ) : ApiSearchContent() {
+        val combinedLatLng = if (latitude != null && longitude != null) {
+            "$latitude,$longitude"
+        } else {
+            latlon
+        }
+    }
 
     @JsonClass(generateAdapter = true)
     data class SearchedTour(

--- a/db/src/main/kotlin/edu/artic/db/models/ApiSearchResult.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ApiSearchResult.kt
@@ -47,7 +47,7 @@ sealed class ApiSearchContent {
     @JsonClass(generateAdapter = true)
     data class SearchedArtwork(
             @Json(name = "id") val artworkId: Int,
-            @Json(name = "is_on_view") val isOnView: Boolean,
+            @Json(name = "is_on_view") val isOnView: Boolean?,
             @Json(name = "title") val title: String,
             /**
              * Just the name of the artist.
@@ -60,7 +60,7 @@ sealed class ApiSearchContent {
              */
             @Json(name = "artist_display") val artist_display: String,
             @Json(name = "image_id") val image_id: String?,
-            @Json(name = "gallery_id") val gallery_id: String,
+            @Json(name = "gallery_id") val gallery_id: String?,
             @Json(name = "latlon") val latlon: String?,
             @Json(name = "latitude") val latitude: String?,
             @Json(name = "longitude") val longitude: String?,

--- a/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticObject.kt
@@ -132,6 +132,7 @@ fun ArticObject.asArticSearchArtworkObject(gallery: ArticGallery? = null): Artic
             artistDisplay = this.artistCulturePlaceDelim,
             location = this.location,
             floor = this.floor,
-            gallery = gallery
+            gallery = gallery,
+            isOnView = isOnView ?: false
     )
 }

--- a/db/src/main/kotlin/edu/artic/db/models/ArticSearchArtworkObject.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticSearchArtworkObject.kt
@@ -31,7 +31,8 @@ data class ArticSearchArtworkObject(
         val artistDisplay: String?,
         val location: String?,
         val floor: Int,
-        val gallery: ArticGallery?
+        val gallery: ArticGallery?,
+        val isOnView: Boolean
 
 ) : Parcelable {
 

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
@@ -106,6 +106,14 @@ class ArtworkDetailFragment :
             }
             .disposedBy(disposeBag)
 
+        viewModel.galleryNumberVisible
+            .bindToMain(binding.galleryNumber.visibility())
+            .disposedBy(disposeBag)
+
+        viewModel.currentlyOffViewVisible
+            .bindToMain(binding.offView.visibility())
+            .disposedBy(disposeBag)
+
         binding.showOnMap.clicks()
             .subscribe { viewModel.onClickShowOnMap() }
             .disposedBy(disposeBag)

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailFragment.kt
@@ -93,11 +93,11 @@ class ArtworkDetailFragment :
             .disposedBy(disposeBag)
 
         viewModel.showOnMapVisible
-            .bindToMain(binding.showOnMap.visibility())
+            .bindToMain(binding.showOnMap.visibility(View.GONE))
             .disposedBy(disposeBag)
 
         viewModel.playAudioVisible
-            .bindToMain(binding.playAudio.visibility(View.INVISIBLE))
+            .bindToMain(binding.playAudio.visibility(View.GONE))
             .disposedBy(disposeBag)
 
         viewModel.galleryNumber

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
@@ -95,7 +95,7 @@ class ArtworkDetailViewModel @Inject constructor(
                 .disposedBy(disposeBag)
 
         articObjectObservable
-            .map { it.isOnView }
+            .map { it.isOnView && it.gallery?.number != null }
             .bindTo(galleryNumberVisible)
             .disposedBy(disposeBag)
 

--- a/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/artwork/ArtworkDetailViewModel.kt
@@ -31,6 +31,10 @@ class ArtworkDetailViewModel @Inject constructor(
     val authorCulturalPlace: Subject<String> = BehaviorSubject.create()
     val showOnMapVisible: Subject<Boolean> = BehaviorSubject.create()
     val playAudioVisible: Subject<Boolean> = BehaviorSubject.create()
+
+    val currentlyOffViewVisible: Subject<Boolean> = BehaviorSubject.create()
+    val galleryNumberVisible: Subject<Boolean> = BehaviorSubject.create()
+
     private val articObjectObservable: Subject<ArticSearchArtworkObject> = BehaviorSubject.create()
 
     var playerService: PlayerService? = null
@@ -65,8 +69,7 @@ class ArtworkDetailViewModel @Inject constructor(
                 .disposedBy(disposeBag)
 
         articObjectObservable
-                .map { it.locationValue }
-                .map { it.isNotEmpty() }
+                .map { it.locationValue.isNotEmpty() && it.isOnView }
                 .bindTo(showOnMapVisible)
                 .disposedBy(disposeBag)
 
@@ -91,6 +94,15 @@ class ArtworkDetailViewModel @Inject constructor(
                 .bindTo(galleryNumber)
                 .disposedBy(disposeBag)
 
+        articObjectObservable
+            .map { it.isOnView }
+            .bindTo(galleryNumberVisible)
+            .disposedBy(disposeBag)
+
+        articObjectObservable
+            .map { !it.isOnView }
+            .bindTo(currentlyOffViewVisible)
+            .disposedBy(disposeBag)
     }
 
     fun onClickShowOnMap() {

--- a/details/src/main/res/layout/fragment_search_audio_detail.xml
+++ b/details/src/main/res/layout/fragment_search_audio_detail.xml
@@ -116,14 +116,6 @@
                 app:layout_constraintWidth_percent=".45"
                 tools:visibility="visible" />
 
-            <!--
-
-            The below Barrier is aligned to 'showOnMap', since we
-            don't expect that to be marked GONE at any of the current
-            uses of this file.
-
-            -->
-
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/buttonPanelGuide"
                 android:layout_width="0dp"
@@ -132,8 +124,7 @@
                 app:barrierDirection="bottom"
                 app:constraint_referenced_ids="showOnMap,playAudio"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/showOnMap" />
+                app:layout_constraintStart_toStartOf="parent"/>
 
             <TextView
                 android:id="@+id/description"
@@ -161,6 +152,19 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/description"
                 tools:text="Through August 5, 2018" />
+            <TextView
+                android:id="@+id/offView"
+                style="@style/DescriptionDate"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/marginDouble"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="@dimen/marginDouble"
+                android:text="@string/search_currently_off_view"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/description"
+                tools:visibility="gone"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/search/src/main/java/edu/artic/search/SearchResultsManager.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultsManager.kt
@@ -146,7 +146,9 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
             artwork?.forEach { searchedArtwork ->
                 val artworkId = searchedArtwork.artworkId.toString()
                 val articObject = articObjectDao.getObjectByIdSynchronously(artworkId)
-                val gallery = articGalleryDao.getGalleryForGalleryIdSynchronously(searchedArtwork.gallery_id)
+                val gallery = searchedArtwork.gallery_id?.let {
+                    articGalleryDao.getGalleryForGalleryIdSynchronously(it)
+                }
                 if (articObject != null) {
                     returnList.add(
                             transformArticObjectToArticSearchObject(
@@ -155,7 +157,7 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
                                     gallery
                             )
                     )
-                } else if (searchedArtwork.isOnView || searchedArtwork.isBoosted == true) {
+                } else if (searchedArtwork.isOnView == true || searchedArtwork.isBoosted == true) {
                     returnList.add(
                             transformSearchedArtworkToSearchArtworkObject(
                                     searchedArtwork,
@@ -194,7 +196,7 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
                 searchedArtwork.combinedLatLng,
                 gallery?.floor ?: INVALID_FLOOR,
                 gallery,
-                searchedArtwork.isOnView
+                searchedArtwork.isOnView ?: false
         )
     }
 

--- a/search/src/main/java/edu/artic/search/SearchResultsManager.kt
+++ b/search/src/main/java/edu/artic/search/SearchResultsManager.kt
@@ -155,7 +155,7 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
                                     gallery
                             )
                     )
-                } else if (searchedArtwork.isOnView) {
+                } else if (searchedArtwork.isOnView || searchedArtwork.isBoosted == true) {
                     returnList.add(
                             transformSearchedArtworkToSearchArtworkObject(
                                     searchedArtwork,
@@ -191,9 +191,10 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
                 imageUrl,
                 searchedArtwork.artistTitle,
                 searchedArtwork.artist_display,
-                searchedArtwork.latlon,
+                searchedArtwork.combinedLatLng,
                 gallery?.floor ?: INVALID_FLOOR,
-                gallery
+                gallery,
+                searchedArtwork.isOnView
         )
     }
 
@@ -212,7 +213,8 @@ class SearchResultsManager(private val searchService: SearchServiceProvider,
                 articObject.artistCulturePlaceDelim,
                 articObject.location,
                 gallery?.floor ?: INVALID_FLOOR,
-                gallery
+                gallery,
+                articObject.isOnView ?: false
         )
     }
 


### PR DESCRIPTION
This PR makes several updates to our Search Result data models and business logic so that we can show artwork which is off-view but boosted, and so that we have an accurate latitude and longitude for showing search results on the map if they _are_ on-view but weren't already in the app data. 