### PR TITLE
Fix: Opt out of edge-to-edge enforcement on search & other screens

### DIFF
--- a/audio/src/main/res/values-v35/styles.xml
+++ b/audio/src/main/res/values-v35/styles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme.CustomToolbar.AudioTheme">
+        <item name="colorPrimary">@color/grape</item>
+        <item name="colorPrimaryDark">@color/grape</item>
+        <item name="android:statusBarColor">@color/grape</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowBackground">@color/grape</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>

--- a/base/src/main/res/values-v35/styles.xml
+++ b/base/src/main/res/values-v35/styles.xml
@@ -14,4 +14,15 @@
         <item name="android:windowAnimationStyle">@null</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
+
+    <style name="AppTheme.CustomToolbar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 </resources>

--- a/info/src/main/res/values-v35/styles.xml
+++ b/info/src/main/res/values-v35/styles.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme.CustomToolbar.InfoTheme">
+        <!-- General theme attributes -->
+        <item name="colorPrimary">@color/brownishOrange</item>
+        <item name="colorPrimaryDark">@color/brownishOrange</item>
+        <item name="colorAccent">@color/brownishOrange</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="android:colorAccent">@color/brownishOrange</item>
+        <item name="android:statusBarColor">@color/brownishOrange</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:fontFamily">@font/ideal_sans_medium</item>
+
+        <!-- Attributes for edu.artic.localization.ui.LanguageSettingsFragment -->
+        <item name="languageSettingsBackgroundColor">@color/white</item>
+        <item name="languageSettingsButtonTextColor">@color/radiobutton_text_color_list</item>
+        <item name="languageSettingsButtonBackground">@drawable/language_radio_button_background
+        </item>
+        <item name="languageSettingsContainsToolbar">true</item>
+        <item name="languageSettingsBodyTextColor">@color/black</item>
+        <item name="languageSettingsTitleTextColor">@color/darkGrey</item>
+        <item name="languageSettingsButtonVerticalBias">0</item>
+        <item name="languageSettingsHasDivider">true</item>
+        <item name="languageSettingsTitleTextAppearance">@style/CardTitleLargeBlack</item>
+        <item name="languageSettingsBodyTextAppearance">@style/BodySansSerifBlackLeft</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>

--- a/location_ui/src/main/res/values-v35/styles.xml
+++ b/location_ui/src/main/res/values-v35/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Very similar to AppTheme.CustomToolbar.MapTheme; This, however, uses 'sea' for the accent color -->
+    <style name="AppTheme.CustomToolbar.Location">
+        <item name="colorAccent">@color/sea</item>
+        <item name="colorPrimary">@color/marine</item>
+        <item name="colorPrimaryDark">@color/marine</item>
+        <item name="android:colorAccent">@color/sea</item>
+        <item name="android:statusBarColor">@color/marine</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>

--- a/media_ui/src/main/res/values-v35/styles.xml
+++ b/media_ui/src/main/res/values-v35/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AudioTutorialTheme" parent="AppTheme.CustomToolbar">
+        <item name="colorPrimary">@color/audioBackground</item>
+        <item name="colorPrimaryDark">@color/audioBackground</item>
+        <item name="android:colorPrimaryDark">@color/audioBackground</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>

--- a/search/src/main/res/values-v35/styles.xml
+++ b/search/src/main/res/values-v35/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SearchTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/audioBackground</item>
+        <item name="colorPrimaryDark">@color/greyText</item>
+        <item name="android:colorPrimaryDark">@color/greyText</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>

--- a/splash/src/main/res/values-v35/styles.xml
+++ b/splash/src/main/res/values-v35/styles.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SplashTheme" parent="AppTheme.CustomToolbar">
+        <item name="colorPrimaryDark">@color/colorPrimary</item>
+        <item name="android:windowBackground">@drawable/splash_gradient</item>
+
+        <!-- 'colorAccent' is used as default tint color for Buttons -->
+        <item name="colorAccent">@color/sea</item>
+        <item name="android:colorAccent">@color/sea</item>
+
+        <!-- 'colorControlActivated' is used by the progress in ProgressBars -->
+        <item name="colorControlActivated">@color/white</item>
+        <item name="android:colorControlActivated">@color/white</item>
+
+        <!-- Attributes for edu.artic.localization.ui.LanguageSettingsFragment -->
+        <item name="languageSettingsBackgroundColor">@color/ugly_blue</item>
+        <item name="languageSettingsButtonTextColor">@color/white</item>
+        <item name="languageSettingsButtonBackground">@drawable/language_radio_button_background
+        </item>
+        <item name="languageSettingsContainsToolbar">false</item>
+        <item name="languageSettingsBodyTextColor">@color/white</item>
+        <item name="languageSettingsTitleTextColor">@color/white</item>
+        <item name="languageSettingsHasDivider">false</item>
+        <item name="languageSettingsButtonVerticalBias">0.8</item>
+        <item name="languageSettingsTitleTextAppearance">@style/LanguageSettingsText</item>
+        <item name="languageSettingsBodyTextAppearance">@style/BodySansSerifWhiteCentered</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
In our previous release, I added flags to our most commonly used Themes to opt us out of edge-to-edge enforcement on the newest versions of Android (essentially the expectation that our UI gracefully covers the entire device screen, accounting for camera cutouts, navigation and status bars, etc). However, I missed that some screens declared their own Themes as well, leading to some ugly clipping and whiteboxing on the search page among others. This PR ensures that all Themes used in our app uniformly opt out of edge-to-edge enforcement.

Before:
<img width="480" alt="Screenshot_1776402220" src="https://github.com/user-attachments/assets/f74fca39-64d8-4ce5-948b-1cba5283a7c2" />

After:
<img width="480" alt="Screenshot_1776402256" src="https://github.com/user-attachments/assets/510a6ec9-ad97-4f2a-afb9-0120c5550b3b" />


Note, however, that this is not a long-term solution. Opting out won't be allowed once we're required to increase our target SDK to 36, which will happen at the end of August, so we'll need to invest effort in truly updating the UI before then.