### PR TITLE
Feature: Improve the app startup experience

### DIFF
--- a/audio/src/main/java/edu/artic/audio/AudioActivity.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioActivity.kt
@@ -7,6 +7,7 @@ import edu.artic.base.utils.preventReselection
 import edu.artic.media.ui.NarrowAudioPlayerFragment
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.linkHome
+import edu.artic.navigation.overrideTransition
 import edu.artic.ui.BaseActivity
 
 //import kotlinx.android.synthetic.main.activity_audio.*
@@ -37,6 +38,7 @@ class AudioActivity : BaseActivity<ActivityAudioBinding>() {
     override fun onBackPressed() {
         if (isRootFragment(R.id.audioLookupFragment)) {
             startActivity(linkHome())
+            overrideTransition()
             return
         }
         super.onBackPressed()

--- a/db/src/main/kotlin/edu/artic/db/AppDataPreferencesManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataPreferencesManager.kt
@@ -3,13 +3,23 @@ package edu.artic.db
 import android.content.Context
 import edu.artic.base.BasePreferencesManager
 
-class AppDataPreferencesManager(context: Context) : BasePreferencesManager(context, "appData") {
+class AppDataPreferencesManager(context: Context) : BasePreferencesManager(context, FILE_NAME) {
+    companion object {
+        private const val FILE_NAME = "appData"
+        private const val LAST_MODIFIED_KEY = "last_modified"
+        private const val DOWNLOADED_NECESSARY_DATA_KEY = "downloaded_necessary_data"
+        private const val SHOW_STARTUP_VIDEO_KEY = "show_startup_video"
+    }
 
     var lastModified: String
-        set(value) = putString("last_modified", value)
-        get() = getString("last_modified", "").orEmpty()
+        set(value) = putString(LAST_MODIFIED_KEY, value)
+        get() = getString(LAST_MODIFIED_KEY, "").orEmpty()
 
     var downloadedNecessaryData: Boolean
-        set(value) = putBoolean("downloaded_necessary_data", value)
-        get() = getBoolean("downloaded_necessary_data", false)
+        set(value) = putBoolean(DOWNLOADED_NECESSARY_DATA_KEY, value)
+        get() = getBoolean(DOWNLOADED_NECESSARY_DATA_KEY, false)
+
+    var shouldShowVideo: Boolean
+        set(value) = putBoolean(SHOW_STARTUP_VIDEO_KEY, value)
+        get() = getBoolean(SHOW_STARTUP_VIDEO_KEY, true)
 }

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -9,6 +9,7 @@ import edu.artic.location.LocationService
 import edu.artic.location.LocationServiceImpl
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.linkHome
+import edu.artic.navigation.overrideTransition
 import edu.artic.ui.BaseActivity
 import edu.artic.ui.findNavController
 //import kotlinx.android.synthetic.main.activity_info.*
@@ -64,6 +65,7 @@ class InfoActivity : BaseActivity<ActivityInfoBinding>() {
     override fun onBackPressed() {
         if (isRootFragment(R.id.informationFragment)) {
             startActivity(linkHome())
+            overrideTransition()
             return
         }
         super.onBackPressed()

--- a/map/src/main/kotlin/edu/artic/map/MapActivity.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapActivity.kt
@@ -11,6 +11,7 @@ import edu.artic.map.databinding.ActivityMapBinding
 import edu.artic.map.tutorial.TutorialPreferencesManager
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.linkHome
+import edu.artic.navigation.overrideTransition
 import edu.artic.ui.BaseActivity
 import javax.inject.Inject
 
@@ -62,6 +63,7 @@ class MapActivity : BaseActivity<ActivityMapBinding>() {
     override fun onBackPressed() {
         if (isRootFragment(R.id.mapFragment)) {
             startActivity(linkHome())
+            overrideTransition()
             return
         }
         super.onBackPressed()

--- a/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
+++ b/media_ui/src/main/java/edu/artic/media/ui/NarrowAudioPlayerFragment.kt
@@ -1,6 +1,8 @@
 package edu.artic.media.ui
 
 //import kotlinx.android.synthetic.main.fragment_bottom_audio_player.*
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
@@ -83,8 +85,15 @@ class NarrowAudioPlayerFragment :
         super.onResume()
         val newAudioIntent = AudioPlayerService.getLaunchIntent(requireContext())
         audioIntent = newAudioIntent
-        requireActivity().startService(newAudioIntent)
-        requireActivity().bindService(newAudioIntent, serviceConnection, 0)
+
+        // Only start the service if the app is in the foreground to prevent a background crash.
+        // See https://issuetracker.google.com/issues/113122354 for context
+        val info = RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(info)
+        if (info.importance <= RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+            requireActivity().startService(newAudioIntent)
+            requireActivity().bindService(newAudioIntent, serviceConnection, 0)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/navigation/src/main/java/edu/artic/navigation/NavigationConstants.kt
+++ b/navigation/src/main/java/edu/artic/navigation/NavigationConstants.kt
@@ -1,6 +1,10 @@
 package edu.artic.navigation
 
+import android.app.Activity
+import android.app.Activity.OVERRIDE_TRANSITION_OPEN
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import edu.artic.base.utils.asDeepLinkIntent
 
 /**
@@ -31,4 +35,15 @@ fun linkHome(): Intent {
     val intent = NavigationConstants.HOME.asDeepLinkIntent()
     intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
     return intent
+}
+
+@Suppress("DEPRECATION")
+fun Context.overrideTransition() {
+    if (this is Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+        } else {
+            overridePendingTransition(0, 0)
+        }
+    }
 }

--- a/navigation/src/main/java/edu/artic/navigation/NavigationSelectListener.kt
+++ b/navigation/src/main/java/edu/artic/navigation/NavigationSelectListener.kt
@@ -2,8 +2,8 @@ package edu.artic.navigation
 
 import android.content.Context
 import android.content.Intent
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import android.view.MenuItem
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import edu.artic.base.R
 import edu.artic.base.utils.asDeepLinkIntent
 
@@ -22,24 +22,28 @@ class NavigationSelectListener(val context: Context) : BottomNavigationView.OnNa
         return when (item.itemId) {
             R.id.action_home -> {
                 context.startActivity(linkHome())
+                context.overrideTransition()
                 false
             }
             R.id.action_map -> {
                 val intent = NavigationConstants.MAP.asDeepLinkIntent()
                 intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
                 context.startActivity(intent)
+                context.overrideTransition()
                 false
             }
             R.id.action_audio -> {
                 val intent = NavigationConstants.AUDIO.asDeepLinkIntent()
                 intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
                 context.startActivity(intent)
+                context.overrideTransition()
                 false
             }
             R.id.action_info -> {
                 val intent = NavigationConstants.INFO.asDeepLinkIntent()
                 intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION
                 context.startActivity(intent)
+                context.overrideTransition()
                 false
             }
             else -> {

--- a/splash/src/main/AndroidManifest.xml
+++ b/splash/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
             android:name=".SplashActivity"
             android:exported="true"
             android:screenOrientation="sensorPortrait"
-            android:theme="@style/SplashTheme">
+            android:theme="@style/SplashTheme"
+            android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashActivity.kt
@@ -7,6 +7,7 @@ import android.app.AlertDialog
 import android.graphics.Matrix
 import android.graphics.SurfaceTexture
 import android.media.MediaPlayer
+import android.media.PlaybackParams
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
@@ -187,7 +188,8 @@ class SplashActivity : BaseViewModelActivity<ActivitySplashBinding, SplashViewMo
             mediaPlayer.setSurface(this.surface)
             mediaPlayer.prepareAsync()
             mediaPlayer.setOnCompletionListener {
-                goToWelcomeActivity(binding.textureView)
+                viewModel.onVideoShown()
+                goToWelcomeActivity(binding.textureView, true)
             }
         } catch (ignored: Throwable) {
             ///TODO: instead, handle errors when we receive the Navigate.Forward event (i.e. when the progressBar is full)
@@ -218,22 +220,15 @@ class SplashActivity : BaseViewModelActivity<ActivitySplashBinding, SplashViewMo
         }).start()
     }
 
-    private fun goToWelcomeActivity(textureView: TextureView) {
+    private fun goToWelcomeActivity(textureView: TextureView, fromVideo: Boolean = false) {
         val intent = NavigationConstants.HOME.asDeepLinkIntent()
-        val options = ActivityOptions
-            .makeSceneTransitionAnimation(this, textureView, "museumImage")
+        val options = if (fromVideo) {
+            ActivityOptions.makeSceneTransitionAnimation(this, textureView, "museumImage")
+        } else {
+            ActivityOptions.makeSceneTransitionAnimation(this)
+        }
         if (!isFinishing) {
-            /**
-             * Shared transition element does not work properly (crashes on some devices) running
-             * Lollipop. Please check https://issuetracker.google.com/issues/35826109
-             */
-            if (Build.VERSION.SDK_INT < VERSION_CODES.M) {
-                startActivity(intent)
-                finish()
-            } else {
-                startActivity(intent, options.toBundle())
-                finishAfterTransition()
-            }
+            startActivity(intent, options.toBundle())
         }
     }
 

--- a/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
+++ b/splash/src/main/kotlin/edu/artic/splash/SplashViewModel.kt
@@ -60,6 +60,13 @@ class SplashViewModel @Inject constructor(
      * Play the museum floor animation video.
      */
     private fun startVideo() {
+        if (!appDaPrefManager.shouldShowVideo) {
+            Navigate.Forward(NavigationEndpoint.Welcome)
+                    .asObservable()
+                    .bindTo(navigateTo)
+            return
+        }
+
         val seenLanguageSettingsDialogBefore = languageSettingsPrefManager.userSelectedLanguage
         Navigate.Forward(NavigationEndpoint.StartVideo(!seenLanguageSettingsDialogBefore))
                 .asObservable().delay(1, TimeUnit.SECONDS)
@@ -77,5 +84,12 @@ class SplashViewModel @Inject constructor(
                     .bindTo(navigateTo)
                     .disposedBy(disposeBag)
         }
+    }
+
+    /**
+     * Mark the video as shown so the user doesn't see it again on future startups
+     */
+    fun onVideoShown() {
+        appDaPrefManager.shouldShowVideo = false
     }
 }

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
@@ -1,11 +1,11 @@
 package edu.artic.welcome
 
 import android.os.Bundle
-import android.transition.Explode
 import android.transition.Fade
 import android.view.Window
 import edu.artic.base.utils.disableShiftMode
 import edu.artic.navigation.NavigationSelectListener
+import edu.artic.navigation.overrideTransition
 import edu.artic.ui.BaseActivity
 import edu.artic.welcome.databinding.ActivityWelcomeBinding
 
@@ -18,7 +18,7 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>() {
         with(window) {
             requestFeature(Window.FEATURE_CONTENT_TRANSITIONS)
             allowEnterTransitionOverlap = true
-            enterTransition = Explode()
+            enterTransition = Fade()
             exitTransition = Fade()
         }
 
@@ -38,7 +38,7 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>() {
         if (supportFragmentManager.backStackEntryCount == 0) {
             if (navController.currentDestination?.id == R.id.welcomeFragment) {
                 finishAffinity()
-                overridePendingTransition(0, 0)
+                overrideTransition()
                 return
             }
         }


### PR DESCRIPTION
This PR groups a couple of related tasks together. First, we want to only show the startup video once after the app is installed; future launches should navigation to the welcome screen as soon as necessary data is downloaded. While implementing that and fixing the transition animation to account for the video no longer being shown, I noticed our navigation tab transitions were incorrectly animating (we want the tabs to swap instantly) on newer Android versions because of an SDK change, so I addressed that by overriding the animations using the new API. Finally, there was an old bug where sometimes when the app launches its lifecycle callbacks will be called before the system considers it fully in the foreground and it tries to start our audio service, which crashes if called from the background. This is just a Weird Android Thing, so we use the approach recommended by the Android team and check our process info before starting said service.

Before:
https://github.com/user-attachments/assets/cf10d3db-17ad-42ea-b2f7-e473144bb4c2

After:
https://github.com/user-attachments/assets/2670c1a8-4340-4b87-b6df-ec511fba4cb9
