### PR TITLE
Feature: Update Exhibitions to match other platforms

### DIFF
--- a/base/src/main/res/values-en/strings.xml
+++ b/base/src/main/res/values-en/strings.xml
@@ -51,4 +51,5 @@
 	<string name="messages_next_action">Next Message</string>
 	<string name="messages_previous_action">Previous Message</string>
 	<string name="search_currently_off_view">Currently Off View</string>
+    <string name="content_ongoing">Ongoing</string>
 </resources>

--- a/base/src/main/res/values-es/strings.xml
+++ b/base/src/main/res/values-es/strings.xml
@@ -51,4 +51,5 @@
 	<string name="messages_next_action">Mensaje siguiente</string>
 	<string name="messages_previous_action">Mensaje anterior</string>
 	<string name="search_currently_off_view">Acutualmente no está exhibido</string>
+    <string name="content_ongoing">En curso</string>
 </resources>

--- a/base/src/main/res/values-fr/strings.xml
+++ b/base/src/main/res/values-fr/strings.xml
@@ -51,4 +51,5 @@
 	<string name="messages_next_action">Message suivant</string>
 	<string name="messages_previous_action">Message précédent</string>
 	<string name="search_currently_off_view">Pas exposé actuellement</string>
+    <string name="content_ongoing">En cours</string>
 </resources>

--- a/base/src/main/res/values-ko/strings.xml
+++ b/base/src/main/res/values-ko/strings.xml
@@ -51,4 +51,5 @@
 	<string name="messages_next_action">다음 메시지</string>
 	<string name="messages_previous_action">이전 메시지</string>
 	<string name="search_currently_off_view">현재 전시 중</string>
+    <string name="content_ongoing">진행 중</string>
 </resources>

--- a/base/src/main/res/values-zh/strings.xml
+++ b/base/src/main/res/values-zh/strings.xml
@@ -51,4 +51,5 @@
 	<string name="messages_next_action">下一條訊息</string>
 	<string name="messages_previous_action">上一條訊息</string>
 	<string name="search_currently_off_view">目前不展出</string>
+    <string name="content_ongoing">进行中</string>
 </resources>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -59,5 +59,6 @@
     <string name="messages_next_action">Next Message</string>
     <string name="messages_previous_action">Previous Message</string>
     <string name="content_gallery_number">Gallery %s</string>
+    <string name="content_ongoing">Ongoing</string>
 
 </resources>

--- a/content_listing/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsAdapter.kt
+++ b/content_listing/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsAdapter.kt
@@ -43,7 +43,11 @@ class AllExhibitionsAdapter :
                 .disposedBy(item.viewDisposeBag)
             item.exhibitionEndDate
                 .map {
-                    context.getString(R.string.content_through_date, it)
+                    if (it.isNotBlank()) {
+                        context.getString(edu.artic.details.R.string.content_through_date, it)
+                    } else {
+                        context.getString(edu.artic.details.R.string.content_ongoing)
+                    }
                 }
                 .bindToMain(description.text())
                 .disposedBy(item.viewDisposeBag)

--- a/content_listing/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsViewModel.kt
+++ b/content_listing/src/main/kotlin/edu/artic/exhibitions/AllExhibitionsViewModel.kt
@@ -73,9 +73,9 @@ class AllExhibitionsCellViewModel(
 
         languageSelector.currentLanguage
                 .map {
-                    exhibition.endTime.format(
+                    exhibition.endTime?.format(
                             HomeExhibition.obtainFormatter(it)
-                    )
+                    ) ?: ""
                 }
                 .bindToMain(exhibitionEndDate)
                 .disposedBy(disposeBag)

--- a/db/schemas/edu.artic.db.AppDatabase/15.json
+++ b/db/schemas/edu.artic.db.AppDatabase/15.json
@@ -1,0 +1,1464 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "5545c23e084a81b3a441bdd9d8b6013e",
+    "entities": [
+      {
+        "tableName": "DashBoard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `featuredTours` TEXT NOT NULL, `featuredExhibitions` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featuredTours",
+            "columnName": "featuredTours",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featuredExhibitions",
+            "columnName": "featuredExhibitions",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticGeneralInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `nid` TEXT NOT NULL, `translations` TEXT NOT NULL, `museumHours` TEXT NOT NULL, `homeMemberPromptText` TEXT NOT NULL, `audioTitle` TEXT NOT NULL, `audioSubtitle` TEXT NOT NULL, `mapTitle` TEXT NOT NULL, `mapSubtitle` TEXT NOT NULL, `infoTitle` TEXT NOT NULL, `infoSubtitle` TEXT NOT NULL, `giftShopsTitle` TEXT NOT NULL, `giftShopsText` TEXT NOT NULL, `membersLoungeTitle` TEXT NOT NULL, `membersLoungeText` TEXT NOT NULL, `seeAllToursIntro` TEXT NOT NULL, `restroomsTitle` TEXT NOT NULL, `restroomsText` TEXT NOT NULL, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translations",
+            "columnName": "translations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "museumHours",
+            "columnName": "museumHours",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeMemberPromptText",
+            "columnName": "homeMemberPromptText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioTitle",
+            "columnName": "audioTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioSubtitle",
+            "columnName": "audioSubtitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mapTitle",
+            "columnName": "mapTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mapSubtitle",
+            "columnName": "mapSubtitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "infoTitle",
+            "columnName": "infoTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "infoSubtitle",
+            "columnName": "infoSubtitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "giftShopsTitle",
+            "columnName": "giftShopsTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "giftShopsText",
+            "columnName": "giftShopsText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "membersLoungeTitle",
+            "columnName": "membersLoungeTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "membersLoungeText",
+            "columnName": "membersLoungeText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seeAllToursIntro",
+            "columnName": "seeAllToursIntro",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restroomsTitle",
+            "columnName": "restroomsTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restroomsText",
+            "columnName": "restroomsText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticGallery",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT, `status` TEXT, `nid` TEXT NOT NULL, `type` TEXT, `location` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `floor` INTEGER NOT NULL, `titleT` TEXT, `galleryId` TEXT, `number` TEXT, `closed` INTEGER, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "floor",
+            "columnName": "floor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleT",
+            "columnName": "titleT",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "galleryId",
+            "columnName": "galleryId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "closed",
+            "columnName": "closed",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticObject",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `status` TEXT, `nid` TEXT NOT NULL, `type` TEXT, `id` INTEGER, `objectId` INTEGER, `altTitles` TEXT, `mainReferenceNumber` TEXT, `boostRank` TEXT, `dateDisplay` TEXT, `artistCulturePlaceDelim` TEXT, `dimensions` TEXT, `artworkTypeTitle` TEXT, `artworkTypeId` TEXT, `creditLine` TEXT, `copyrightNotice` TEXT, `subjectId` TEXT, `techniqueId` TEXT, `color` TEXT, `tourTitles` TEXT, `location` TEXT, `image_filename` TEXT, `image_url` TEXT, `imageFileMime` TEXT, `imageFileSize` TEXT, `imageWidth` TEXT, `imageHeight` TEXT, `thumbnailFullPath` TEXT, `largeImageFullPath` TEXT, `titleT` TEXT, `galleryLocation` TEXT, `referenceNum` TEXT, `audioCommentary` TEXT NOT NULL, `highlightedObject` TEXT, `audioTranscript` TEXT, `objectSelectorNumber` TEXT, `isOnView` INTEGER, `floor` INTEGER NOT NULL, `thumbnail_crop_rectx` TEXT, `thumbnail_crop_recty` TEXT, `thumbnail_crop_rectwidth` TEXT, `thumbnail_crop_rectheight` TEXT, `large_image_crop_rectx` TEXT, `large_image_crop_recty` TEXT, `large_image_crop_rectwidth` TEXT, `large_image_crop_rectheight` TEXT, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "objectId",
+            "columnName": "objectId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "altTitles",
+            "columnName": "altTitles",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mainReferenceNumber",
+            "columnName": "mainReferenceNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "boostRank",
+            "columnName": "boostRank",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateDisplay",
+            "columnName": "dateDisplay",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "artistCulturePlaceDelim",
+            "columnName": "artistCulturePlaceDelim",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dimensions",
+            "columnName": "dimensions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "artworkTypeTitle",
+            "columnName": "artworkTypeTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "artworkTypeId",
+            "columnName": "artworkTypeId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "creditLine",
+            "columnName": "creditLine",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "copyrightNotice",
+            "columnName": "copyrightNotice",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "subjectId",
+            "columnName": "subjectId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "techniqueId",
+            "columnName": "techniqueId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourTitles",
+            "columnName": "tourTitles",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image_filename",
+            "columnName": "image_filename",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image_url",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileMime",
+            "columnName": "imageFileMime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileSize",
+            "columnName": "imageFileSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageWidth",
+            "columnName": "imageWidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageHeight",
+            "columnName": "imageHeight",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailFullPath",
+            "columnName": "thumbnailFullPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageFullPath",
+            "columnName": "largeImageFullPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "titleT",
+            "columnName": "titleT",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "galleryLocation",
+            "columnName": "galleryLocation",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "referenceNum",
+            "columnName": "referenceNum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioCommentary",
+            "columnName": "audioCommentary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlightedObject",
+            "columnName": "highlightedObject",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioTranscript",
+            "columnName": "audioTranscript",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "objectSelectorNumber",
+            "columnName": "objectSelectorNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isOnView",
+            "columnName": "isOnView",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "floor",
+            "columnName": "floor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailCropRectV2.x",
+            "columnName": "thumbnail_crop_rectx",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailCropRectV2.y",
+            "columnName": "thumbnail_crop_recty",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailCropRectV2.width",
+            "columnName": "thumbnail_crop_rectwidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailCropRectV2.height",
+            "columnName": "thumbnail_crop_rectheight",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropRectV2.x",
+            "columnName": "large_image_crop_rectx",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropRectV2.y",
+            "columnName": "large_image_crop_recty",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropRectV2.width",
+            "columnName": "large_image_crop_rectwidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropRectV2.height",
+            "columnName": "large_image_crop_rectheight",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticAudioFile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT, `status` TEXT, `nid` TEXT NOT NULL, `type` TEXT, `translations` TEXT NOT NULL, `fileName` TEXT, `fileUrl` TEXT, `fileMime` TEXT, `fileSize` TEXT, `transcript` TEXT, `credits` TEXT, `trackTitle` TEXT, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "translations",
+            "columnName": "translations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileMime",
+            "columnName": "fileMime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "transcript",
+            "columnName": "transcript",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "credits",
+            "columnName": "credits",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trackTitle",
+            "columnName": "trackTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticTour",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `status` TEXT, `nid` TEXT NOT NULL, `type` TEXT, `translations` TEXT NOT NULL, `location` TEXT, `latitude` TEXT, `longitude` TEXT, `floor` INTEGER, `imageFileName` TEXT, `imageUrl` TEXT, `imageFileMime` TEXT, `imageFileSize` TEXT, `imageWidth` TEXT, `imageHeight` TEXT, `thumbnailFullPath` TEXT, `largeImageFullPath` TEXT, `tourBanner` TEXT, `selectorNumber` TEXT, `description` TEXT, `descriptionHtml` TEXT, `intro` TEXT, `introHtml` TEXT, `tourDuration` TEXT, `tourAudio` TEXT, `weight` INTEGER, `tourStops` TEXT NOT NULL, `large_image_cropx` TEXT, `large_image_cropy` TEXT, `large_image_cropwidth` TEXT, `large_image_cropheight` TEXT, `tour_catid` TEXT, `tour_cattitle` TEXT, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "translations",
+            "columnName": "translations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "floor",
+            "columnName": "floor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileName",
+            "columnName": "imageFileName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileMime",
+            "columnName": "imageFileMime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileSize",
+            "columnName": "imageFileSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageWidth",
+            "columnName": "imageWidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageHeight",
+            "columnName": "imageHeight",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailFullPath",
+            "columnName": "thumbnailFullPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageFullPath",
+            "columnName": "largeImageFullPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourBanner",
+            "columnName": "tourBanner",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selectorNumber",
+            "columnName": "selectorNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "descriptionHtml",
+            "columnName": "descriptionHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "intro",
+            "columnName": "intro",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "introHtml",
+            "columnName": "introHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourDuration",
+            "columnName": "tourDuration",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourAudio",
+            "columnName": "tourAudio",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourStops",
+            "columnName": "tourStops",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "largeImageCropV2.x",
+            "columnName": "large_image_cropx",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropV2.y",
+            "columnName": "large_image_cropy",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropV2.width",
+            "columnName": "large_image_cropwidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "largeImageCropV2.height",
+            "columnName": "large_image_cropheight",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category.id",
+            "columnName": "tour_catid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category.title",
+            "columnName": "tour_cattitle",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticMapAnnotation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT, `status` TEXT, `nid` TEXT NOT NULL, `type` TEXT, `location` TEXT, `latitude` TEXT, `longitude` TEXT, `floor` INTEGER, `description` TEXT, `label` TEXT, `annotationType` TEXT, `textType` TEXT, `amenityType` TEXT, `imageFilename` TEXT, `imageUrl` TEXT, `imageFileMime` TEXT, `imageFileSize` TEXT, `imageWidth` TEXT, `imageHeight` TEXT, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "floor",
+            "columnName": "floor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "annotationType",
+            "columnName": "annotationType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "textType",
+            "columnName": "textType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amenityType",
+            "columnName": "amenityType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFilename",
+            "columnName": "imageFilename",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileMime",
+            "columnName": "imageFileMime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageFileSize",
+            "columnName": "imageFileSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageWidth",
+            "columnName": "imageWidth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageHeight",
+            "columnName": "imageHeight",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticExhibition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`short_description` TEXT, `aic_start_at` TEXT NOT NULL, `imageUrl` TEXT, `web_url` TEXT, `gallery_id` TEXT, `id` INTEGER NOT NULL, `aic_end_at` TEXT, `title` TEXT NOT NULL, `position` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `floor` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "short_description",
+            "columnName": "short_description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aic_start_at",
+            "columnName": "aic_start_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "web_url",
+            "columnName": "web_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "gallery_id",
+            "columnName": "gallery_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aic_end_at",
+            "columnName": "aic_end_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "floor",
+            "columnName": "floor",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticExhibitionCMS",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sort` INTEGER NOT NULL, `title` TEXT NOT NULL, `imageUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sort",
+            "columnName": "sort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`short_description` TEXT, `image` TEXT, `imageUrl` TEXT, `end_at` TEXT NOT NULL, `button_url` TEXT, `description` TEXT, `location` TEXT, `id` TEXT NOT NULL, `button_text` TEXT, `title` TEXT NOT NULL, `start_at` TEXT NOT NULL, `isTicketed` INTEGER NOT NULL, `isSalesButtonHidden` INTEGER, `onSaleAt` TEXT, `offSaleAt` TEXT, `buttonCaption` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "short_description",
+            "columnName": "short_description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "end_at",
+            "columnName": "end_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "button_url",
+            "columnName": "button_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "button_text",
+            "columnName": "button_text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start_at",
+            "columnName": "start_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTicketed",
+            "columnName": "isTicketed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSalesButtonHidden",
+            "columnName": "isSalesButtonHidden",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "onSaleAt",
+            "columnName": "onSaleAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "offSaleAt",
+            "columnName": "offSaleAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "buttonCaption",
+            "columnName": "buttonCaption",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticDataObject",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`imageServerUrl` TEXT NOT NULL, `dataApiUrl` TEXT NOT NULL, `exhibitionsEndpoint` TEXT NOT NULL, `artworksEndpoint` TEXT, `galleriesEndpoint` TEXT, `imagesEndpoint` TEXT, `eventsEndpoint` TEXT, `autocompleteEndpoint` TEXT, `toursEndpoint` TEXT, `multiSearchEndpoint` TEXT, `membershipUrl` TEXT, `websiteUrl` TEXT, `ticketsUrl` TEXT, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "imageServerUrl",
+            "columnName": "imageServerUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataApiUrl",
+            "columnName": "dataApiUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exhibitionsEndpoint",
+            "columnName": "exhibitionsEndpoint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artworksEndpoint",
+            "columnName": "artworksEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "galleriesEndpoint",
+            "columnName": "galleriesEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imagesEndpoint",
+            "columnName": "imagesEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "eventsEndpoint",
+            "columnName": "eventsEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "autocompleteEndpoint",
+            "columnName": "autocompleteEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "toursEndpoint",
+            "columnName": "toursEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "multiSearchEndpoint",
+            "columnName": "multiSearchEndpoint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "membershipUrl",
+            "columnName": "membershipUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "websiteUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ticketsUrl",
+            "columnName": "ticketsUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticMapFloor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`label` TEXT NOT NULL, `floorPlan` TEXT, `anchorPixel1` TEXT, `anchorPixel2` TEXT, `anchorLocation1` TEXT, `anchorLocation2` TEXT, `tiles` TEXT NOT NULL, PRIMARY KEY(`label`))",
+        "fields": [
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "floorPlan",
+            "columnName": "floorPlan",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorPixel1",
+            "columnName": "anchorPixel1",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorPixel2",
+            "columnName": "anchorPixel2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorLocation1",
+            "columnName": "anchorLocation1",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorLocation2",
+            "columnName": "anchorLocation2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tiles",
+            "columnName": "tiles",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "label"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticSearchSuggestionsObject",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`searchStrings` TEXT NOT NULL, `searchObjects` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "searchStrings",
+            "columnName": "searchStrings",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchObjects",
+            "columnName": "searchObjects",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ArticMessage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`nid` TEXT NOT NULL, `title` TEXT, `messageType` TEXT, `expirationThreshold` INTEGER, `tourExit` TEXT, `isPersistent` INTEGER, `message` TEXT, `action` TEXT, `actionTitle` TEXT, `translations` TEXT NOT NULL, PRIMARY KEY(`nid`))",
+        "fields": [
+          {
+            "fieldPath": "nid",
+            "columnName": "nid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "messageType",
+            "columnName": "messageType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "expirationThreshold",
+            "columnName": "expirationThreshold",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tourExit",
+            "columnName": "tourExit",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isPersistent",
+            "columnName": "isPersistent",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actionTitle",
+            "columnName": "actionTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "translations",
+            "columnName": "translations",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "nid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5545c23e084a81b3a441bdd9d8b6013e')"
+    ]
+  }
+}

--- a/db/src/main/kotlin/edu/artic/db/ApiBodyGenerator.kt
+++ b/db/src/main/kotlin/edu/artic/db/ApiBodyGenerator.kt
@@ -1,5 +1,8 @@
 package edu.artic.db
 
+import kotlin.String
+import kotlin.collections.mutableMapOf
+
 /**
  * This file contains mechanisms for creating API calls to the general-purpose
  * [data API][edu.artic.db.models.ArticDataObject.dataApiUrl].
@@ -18,29 +21,33 @@ sealed class ApiBodyGenerator {
         fun createExhibitionQueryBody(): MutableMap<String, Any> {
             val postParams = mutableMapOf<String, Any>()
             postParams["fields"] = listOf(
-                    "id",
-                    "title",
-                    "short_description",
-                    "image_url",
-                    "gallery_id",
-                    "web_url",
-                    "aic_start_at",
-                    "aic_end_at"
+                "id",
+                "title",
+                "aic_start_at",
+                "aic_end_at",
+                "short_description",
+                "image_url",
+                "gallery_id",
+                "web_url",
+                "position"
             )
-            postParams["sort"] = listOf("aic_start_at", "aic_end_at")
+
             postParams["query"] = mutableMapOf<String, Any>().apply {
                 //Boolean map
                 this["bool"] = mutableMapOf<String, Any>().apply {
-                    this["must"] = restrictToTimeFrame(
-                            startKey = "aic_start_at",
-                            endKey = "aic_end_at"
-                    )
+                    this["must"] = mutableListOf<Any>().apply {
 
-                    this["must_not"] = mutableListOf<Any>().apply {
                         this.add(mutableMapOf<String, Any>().apply {
-                            //range
                             this["term"] = mutableMapOf<String, Any>().apply {
-                                this["status"] = "Closed"
+                                this["is_featured"] = "true"
+                            }
+                        })
+
+                        this.add(mutableMapOf<String, Any>().apply {
+                            this["range"] = mutableMapOf<String, Any>().apply {
+                                this["aic_start_at"] = mutableMapOf<String, String>().apply {
+                                    this["lte"] = "now"
+                                }
                             }
                         })
                     }

--- a/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDataManager.kt
@@ -423,14 +423,10 @@ class AppDataManager @Inject constructor(
                                     val exhibitionsById = list.associateBy { it.id.toString() }
 
                                     cmsExhibitionList.forEach { exhibitionCMS: ArticExhibitionCMS ->
-                                        exhibitionsById[exhibitionCMS.id]?.order =
-                                            exhibitionCMS.sort
                                         // Override with exhibitions optional images from CMS, if available
                                         exhibitionCMS.imageUrl?.let {
                                             exhibitionsById[exhibitionCMS.id]?.imageUrl = it
                                         }
-                                        exhibitionsById[exhibitionCMS.id]?.order =
-                                            exhibitionCMS.sort
                                     }
 
 

--- a/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
+++ b/db/src/main/kotlin/edu/artic/db/AppDatabase.kt
@@ -23,7 +23,7 @@ import edu.artic.db.models.*
             ArticSearchSuggestionsObject::class,
             ArticMessage::class
         ],
-        version = 14,
+        version = 15,
         exportSchema = true
 )
 @TypeConverters(AppConverters::class)

--- a/db/src/main/kotlin/edu/artic/db/daos/ArticExhibitionDao.kt
+++ b/db/src/main/kotlin/edu/artic/db/daos/ArticExhibitionDao.kt
@@ -16,10 +16,10 @@ interface ArticExhibitionDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun updateExhibitions(exhibitions: List<ArticExhibition>)
 
-    @Query("select * from ArticExhibition order by `order`")
+    @Query("select * from ArticExhibition order by `position`")
     fun getAllExhibitions(): Flowable<List<ArticExhibition>>
 
-    @Query("select * from ArticExhibition order by `order` limit 6")
+    @Query("select * from ArticExhibition order by `position` limit 6")
     fun getExhibitionSummary(): Flowable<List<ArticExhibition>>
 
     @Query("select * from ArticExhibition where id = :id")

--- a/db/src/main/kotlin/edu/artic/db/models/ArticExhibition.kt
+++ b/db/src/main/kotlin/edu/artic/db/models/ArticExhibition.kt
@@ -17,9 +17,9 @@ data class ArticExhibition(
         @Json(name = "web_url") val web_url: String?,
         @Json(name = "gallery_id") val gallery_id: String?,
         @Json(name = "id") @PrimaryKey val id: Int,
-        @Json(name = "aic_end_at") val aic_end_at: ZonedDateTime,
+        @Json(name = "aic_end_at") val aic_end_at: ZonedDateTime?,
         @Json(name = "title") val title: String,
-        var order: Int = -1,
+        @Json(name = "position") val position: Int,
 
         /**
          * This value is defined by the associated [ArticGallery], associated
@@ -50,9 +50,9 @@ data class ArticExhibition(
             }
         }
 
-    val endTime: ZonedDateTime
+    val endTime: ZonedDateTime?
         get() {
-            return aic_end_at.toCurrentTimeZone()
+            return aic_end_at?.toCurrentTimeZone()
         }
 
 }

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailFragment.kt
@@ -145,7 +145,13 @@ class ExhibitionDetailFragment :
             .disposedBy(disposeBag)
 
         viewModel.throughDate
-            .map { getString(R.string.content_through_date, it) }
+            .map {
+                if (it.isNotBlank()) {
+                    getString(R.string.content_through_date, it)
+                } else {
+                    getString(R.string.content_ongoing)
+                }
+            }
             .bindToMain(binding.throughDate.text())
             .disposedBy(disposeBag)
 

--- a/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
+++ b/details/src/main/kotlin/edu/artic/exhibitions/ExhibitionDetailViewModel.kt
@@ -100,11 +100,11 @@ constructor(dataObjectDao: ArticDataObjectDao,
                         exhibitionObservable
                 )
                 .map { (locale, exhibition) ->
-                    exhibition.endTime.format(
+                    exhibition.endTime?.format(
                             HomeExhibition.obtainFormatter(
                                     locale
                             )
-                    )
+                    ) ?: ""
                 }.bindTo(throughDate)
                 .disposedBy(disposeBag)
     }

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeExhibitionAdapter.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeExhibitionAdapter.kt
@@ -30,7 +30,11 @@ class OnViewAdapter :
 
             item.exhibitionDate
                 .map {
-                    context.getString(R.string.content_through_date, it)
+                    if (it.isNotBlank()) {
+                        context.getString(edu.artic.details.R.string.content_through_date, it)
+                    } else {
+                        context.getString(edu.artic.details.R.string.content_ongoing)
+                    }
                 }
                 .bindToMain(exhibitionDate.text())
                 .disposedBy(item.viewDisposeBag)

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeViewModel.kt
@@ -291,7 +291,7 @@ class WelcomeExhibitionCellViewModel(
                     HomeExhibition.obtainFormatter(it)
                 }
                 .map {
-                    exhibition.endTime.format(it)
+                    exhibition.endTime?.format(it) ?: ""
                 }
                 .bindToMain(exhibitionDate)
                 .disposedBy(disposeBag)


### PR DESCRIPTION
This PR updates the query that Android uses to fetch Exhibitions as well as removing the outdated client-side sorting logic referencing the CMS order; we now sort Exhibitions according to their `position` property from the API, making the Android experience totally consistent with iOS and much closer to the website's. The query that Android was previously using was filtering out any Exhibitions without an end date, so we also had to update the UI logic a little bit to allow for null end dates and show "Ongoing" when the end date is null; this is also consistent with iOS.

Before:

https://github.com/user-attachments/assets/bc90115b-d1b3-40aa-abf3-faae85489c74


After:

https://github.com/user-attachments/assets/8619eb34-835d-4625-9615-a96b864ce842