### PR TITLE
Fix: Address app bar layout issues

### DIFF
--- a/audio/src/main/java/edu/artic/audio/AudioActivity.kt
+++ b/audio/src/main/java/edu/artic/audio/AudioActivity.kt
@@ -2,7 +2,6 @@ package edu.artic.audio
 
 import android.os.Bundle
 import edu.artic.audio.databinding.ActivityAudioBinding
-import edu.artic.base.utils.disableShiftMode
 import edu.artic.base.utils.preventReselection
 import edu.artic.media.ui.NarrowAudioPlayerFragment
 import edu.artic.navigation.NavigationSelectListener
@@ -28,7 +27,6 @@ class AudioActivity : BaseActivity<ActivityAudioBinding>() {
         super.onCreate(savedInstanceState)
 
         binding.bottomNavigation.apply {
-            disableShiftMode(R.color.audio_menu_color_list)
             selectedItemId = R.id.action_audio
             preventReselection()
             setOnNavigationItemSelectedListener(NavigationSelectListener(this.context))

--- a/audio/src/main/res/layout/activity_audio.xml
+++ b/audio/src/main/res/layout/activity_audio.xml
@@ -25,6 +25,8 @@
         style="@style/BottomNav"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:itemTextColor="@color/audio_menu_color_list"
+        app:itemIconTint="@color/audio_menu_color_list"
         app:layout_constrainedHeight="true"
         app:layout_constraintTop_toBottomOf="@id/container" />
 

--- a/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
+++ b/base/src/main/java/edu/artic/base/utils/ViewExtensions.kt
@@ -1,56 +1,9 @@
 package edu.artic.base.utils
 
-import android.annotation.SuppressLint
-import android.graphics.Typeface
-import com.google.android.material.bottomnavigation.BottomNavigationItemView
-import com.google.android.material.bottomnavigation.BottomNavigationMenuView
-import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
 import android.view.MenuItem
 import android.view.View
-import android.widget.TextView
-import edu.artic.base.R
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
-
-/**
- * This hack is required for displaying title below icon.
- * There is an api available to achieve this in support library 28-alpha1 (labelVisibilityMode mode).
- * Once support library goes stable we can remove this hack.
- *
- * @see https://stackoverflow.com/a/47407229/4253091
- * @param colorList ColorStateList for icon and text
- */
-fun BottomNavigationView.disableShiftMode(colorList: Int = 0) {
-    val menuView = getChildAt(0) as BottomNavigationMenuView
-
-    // While we're adjusting the other properties, we can normalize the font in use too.
-    val type: Typeface? = ResourcesCompat.getFont(context, R.font.ideal_sans_semibold)
-
-    @SuppressLint("RestrictedApi")
-    for (i in 0 until menuView.childCount) {
-        (menuView.getChildAt(i) as BottomNavigationItemView).apply {
-            setChecked(false)
-            if (type != null) {
-                overrideLabelFont(type)
-            }
-            if (colorList > 0) {
-                setIconTintList(ContextCompat.getColorStateList(this.context, colorList))
-                setTextColor(ContextCompat.getColorStateList(this.context, colorList))
-            }
-        }
-    }
-}
-
-/**
- * There's no other API for defining these font styles. We just
- * find and set Typeface on the `smallLabel` and 'largeLabel`
- * directly.
- */
-private fun BottomNavigationItemView.overrideLabelFont(font: Typeface) {
-    findViewById<TextView?>(R.id.smallLabel)?.typeface = font
-    findViewById<TextView?>(R.id.largeLabel)?.typeface = font
-}
 
 /**
  * Special implementation of [BottomNavigationView.OnNavigationItemReselectedListener]

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
                 timber                  : 'com.jakewharton.timber:timber:5.0.1',
                 threeten                : 'com.jakewharton.threetenabp:threetenabp:1.1.1',
                 v4_support              : 'androidx.legacy:legacy-support-v4:1.0.0',
-                design_support          : 'com.google.android.material:material:1.0.0',
+                design_support          : 'com.google.android.material:material:1.13.0',
                 constraint_layout       : 'androidx.constraintlayout:constraintlayout:2.2.1',
                 glide                   : "com.github.bumptech.glide:glide:${glide_version}",
                 glide_compiler          : "com.github.bumptech.glide:compiler:${glide_version}",

--- a/info/src/main/java/edu/artic/info/InfoActivity.kt
+++ b/info/src/main/java/edu/artic/info/InfoActivity.kt
@@ -1,9 +1,7 @@
 package edu.artic.info
 
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.os.Bundle
-import edu.artic.base.utils.disableShiftMode
 import edu.artic.info.databinding.ActivityInfoBinding
 import edu.artic.location.LocationService
 import edu.artic.location.LocationServiceImpl
@@ -26,7 +24,6 @@ class InfoActivity : BaseActivity<ActivityInfoBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.bottomNavigation.apply {
-            disableShiftMode(R.color.info_menu_color_list)
             selectedItemId = R.id.action_info
             setOnNavigationItemReselectedListener {
                 navController.popBackStack(R.id.informationFragment, false)

--- a/info/src/main/res/layout/activity_info.xml
+++ b/info/src/main/res/layout/activity_info.xml
@@ -32,6 +32,8 @@
         android:id="@+id/bottomNavigation"
         style="@style/BottomNav"
         android:layout_width="0dp"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        app:itemTextColor="@color/info_menu_color_list"
+        app:itemIconTint="@color/info_menu_color_list" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/map/src/main/kotlin/edu/artic/map/MapActivity.kt
+++ b/map/src/main/kotlin/edu/artic/map/MapActivity.kt
@@ -4,7 +4,6 @@ package edu.artic.map
 import android.os.Bundle
 import com.bumptech.glide.Glide
 import com.bumptech.glide.MemoryCategory
-import edu.artic.base.utils.disableShiftMode
 import edu.artic.base.utils.preventReselection
 import edu.artic.location.LocationPreferenceManager
 import edu.artic.map.databinding.ActivityMapBinding
@@ -38,7 +37,6 @@ class MapActivity : BaseActivity<ActivityMapBinding>() {
 
         binding.bottomNavigation.apply {
 
-            disableShiftMode(R.color.map_menu_color_list)
             selectedItemId = R.id.action_map
 
             preventReselection()

--- a/map/src/main/res/layout/activity_map.xml
+++ b/map/src/main/res/layout/activity_map.xml
@@ -33,6 +33,8 @@
         style="@style/BottomNav"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:itemTextColor="@color/map_menu_color_list"
+        app:itemIconTint="@color/map_menu_color_list"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/map/src/main/res/layout/fragment_map.xml
+++ b/map/src/main/res/layout/fragment_map.xml
@@ -121,13 +121,18 @@
             tools:text="Use the map to find food, facilities, and audio-enhanced artworks." />
     </LinearLayout>
 
-
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
     <ImageView
         android:id="@+id/searchIcon"
         style="@style/Search.PrimaryScreen"
-        android:layout_marginTop="@dimen/statusBarHeightPlus10"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginTop="@dimen/marginOneHalf"/>
+
+    </FrameLayout>
 
     <FrameLayout
         android:id="@+id/infocontainer"

--- a/navigation/src/main/res/values/styles.xml
+++ b/navigation/src/main/res/values/styles.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- Style for android.support.design.widget.BottomNavigationView layouts -->
     <style name="BottomNav">
+        <item name="android:background">@color/nav_bar_background</item>
         <item name="itemBackground">@color/nav_bar_background</item>
         <item name="itemTextColor">@color/nav_bar_unselected</item>
         <item name="layout_constraintBottom_toBottomOf">parent</item>
@@ -9,5 +10,8 @@
         <item name="layout_constraintStart_toStartOf">parent</item>
         <item name="labelVisibilityMode">labeled</item>
         <item name="menu">@menu/navigation_menu</item>
+        <item name="android:fontFamily">@font/ideal_sans_semibold</item>
+        <item name="itemPaddingTop">@dimen/marginHalf</item>
+        <item name="itemPaddingBottom">@dimen/marginHalf</item>
     </style>
 </resources>

--- a/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
+++ b/welcome/src/main/kotlin/edu/artic/welcome/WelcomeActivity.kt
@@ -3,7 +3,6 @@ package edu.artic.welcome
 import android.os.Bundle
 import android.transition.Fade
 import android.view.Window
-import edu.artic.base.utils.disableShiftMode
 import edu.artic.navigation.NavigationSelectListener
 import edu.artic.navigation.overrideTransition
 import edu.artic.ui.BaseActivity
@@ -25,7 +24,6 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>() {
         super.onCreate(savedInstanceState)
 
         binding.bottomNavigation.apply {
-            disableShiftMode(R.color.menu_color_list)
             selectedItemId = R.id.action_home
             setOnNavigationItemReselectedListener {
                 navController.popBackStack(R.id.welcomeFragment, false)

--- a/welcome/src/main/res/layout/activity_welcome.xml
+++ b/welcome/src/main/res/layout/activity_welcome.xml
@@ -32,6 +32,8 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"
         style="@style/BottomNav"
+        app:itemTextColor="@color/menu_color_list"
+        app:itemIconTint="@color/menu_color_list"
         android:layout_width="0dp"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
There was an existing production bug in the Android app which seemingly isn't reproducible on all devices/versions that sometimes caused padding to be inserted at the top of the nested scrollview that all of our content renders in on the Welcome and Info pages. After some digging, it looks like this was caused by an internal bug in the [app bar's scrolling view behavior](https://developer.android.com/reference/com/google/android/material/appbar/AppBarLayout.ScrollingViewBehavior). Updating the Material Design dependency fixed that, but it broke an old workaround for customizing the Bottom Navigation Bar. Fortunately, the updated dependency now has direct APIs for that and we no longer need the workaround at all! 

Before:
<img height="360" alt="Screenshot_20260510_235031" src="https://github.com/user-attachments/assets/51277ad3-879e-4c26-bac6-93293342d078" />

After:
<img height="360" alt="Screenshot_20260510_235207" src="https://github.com/user-attachments/assets/49283998-ec89-4419-a522-258b55341896" />


As a bonus, while digging into the app bar layout I also noticed that the Map screen's search icon wasn't properly aligned with the search icons on other screens because it's not actually part of the app bar, it's just a standalone element in the layout and it wasn't respecting the system insets. That's now fixed as well.

Before:
<img height="360" alt="Screenshot_20260510_235754" src="https://github.com/user-attachments/assets/6aa89050-f9e6-4aae-8b45-9511b26f5466" />

After:
<img height="360" alt="Screenshot_20260510_235535" src="https://github.com/user-attachments/assets/6f59f1ba-c10b-4f84-831c-53dc0363a947" />
